### PR TITLE
Migrate Customer Classes

### DIFF
--- a/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
@@ -71,5 +71,7 @@ permissionset 4031 "HybridGP - Edit"
                     tabledata "GP SY40101" = RIMD,
                     tabledata "GP CM20600" = RIMD,
                     tabledata "GP MC40200" = IMD,
-                    tabledata "GP SY06000" = IMD;
+                    tabledata "GP SY06000" = IMD,
+                    tabledata "GP RM00101" = IMD,
+                    tabledata "GP RM00201" = IMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
@@ -96,5 +96,7 @@ permissionset 4029 "HybridGP - Objects"
                     table "GP SY40101" = X,
                     table "GP CM20600" = X,
                     table "GP MC40200" = X,
-                    table "GP SY06000" = X;
+                    table "GP SY06000" = X,
+                    table "GP RM00101" = X,
+                    table "GP RM00201" = X;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
@@ -71,5 +71,7 @@ permissionset 4032 "HybridGP - Read"
                     tabledata "GP SY40101" = R,
                     tabledata "GP CM20600" = R,
                     tabledata "GP MC40200" = R,
-                    tabledata "GP SY06000" = R;
+                    tabledata "GP SY06000" = R,
+                    tabledata "GP RM00101" = R,
+                    tabledata "GP RM00201" = R;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
@@ -64,5 +64,7 @@ permissionsetextension 4025 "D365 BASIC - HGP" extends "D365 BASIC"
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP RM00101" = RIMD,
+                  tabledata "GP RM00201" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
@@ -64,5 +64,7 @@ permissionsetextension 4026 "D365 BASIC ISV - HGP" extends "D365 BASIC ISV"
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP RM00101" = RIMD,
+                  tabledata "GP RM00201" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
@@ -64,5 +64,7 @@ permissionsetextension 4027 "D365 TEAM MEMBER - HGP" extends "D365 TEAM MEMBER"
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP RM00101" = RIMD,
+                  tabledata "GP RM00201" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/intelligentcloudHGP.permisisonsetextension.al
+++ b/Apps/W1/HybridGP/app/Permissions/intelligentcloudHGP.permisisonsetextension.al
@@ -64,5 +64,7 @@ permissionsetextension 4028 "INTELLIGENT CLOUD - HGP" extends "INTELLIGENT CLOUD
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP RM00101" = RIMD,
+                  tabledata "GP RM00201" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
@@ -400,8 +400,8 @@ codeunit 4018 "GP Customer Migrator"
 
             ClassId := GPRM00101.CUSTCLAS.Trim();
             if ClassId <> '' then
-                if not CustomerPostingGroup.Get(ClassId) then
-                    if Customer.Get(GPRM00101.CUSTNMBR) then
+                if Customer.Get(GPRM00101.CUSTNMBR) then begin
+                    if not CustomerPostingGroup.Get(ClassId) then
                         if GPRM00201.Get(ClassId) then begin
                             CustomerPostingGroup.Validate("Code", ClassId);
                             CustomerPostingGroup.Validate("Description", GPRM00201.CLASDSCR);
@@ -444,10 +444,11 @@ codeunit 4018 "GP Customer Migrator"
                             end;
 
                             CustomerPostingGroup.Insert();
-
-                            Customer.Validate("Customer Posting Group", ClassId);
-                            Customer.Modify(true);
                         end;
+
+                    Customer.Validate("Customer Posting Group", ClassId);
+                    Customer.Modify(true);
+                end;
         until GPRM00101.Next() = 0;
     end;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
@@ -375,4 +375,79 @@ codeunit 4018 "GP Customer Migrator"
         HelperFunctions.UpdateFieldWithValue(RecordVariant, MigrationGPCustTrans.FieldNo(GLDocNo), DocumentNo);
     end;
 
+    procedure MigrateCustomerClasses()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPRM00101: Record "GP RM00101";
+        GPRM00201: Record "GP RM00201";
+        CustomerPostingGroup: Record "Customer Posting Group";
+        Customer: Record Customer;
+        HelperFunctions: Codeunit "Helper Functions";
+        ClassId: Text[11];
+        AccountNumber: Code[20];
+        MigrateCustomerClasses: Boolean;
+    begin
+        MigrateCustomerClasses := true;
+        if GPCompanyAdditionalSettings.Get(CompanyName()) then
+            MigrateCustomerClasses := GPCompanyAdditionalSettings."Migrate Customer Classes";
+
+        if not MigrateCustomerClasses or not GPRM00101.FindSet() then
+            exit;
+
+        repeat
+            Clear(GPRM00201);
+            Clear(CustomerPostingGroup);
+
+            ClassId := GPRM00101.CUSTCLAS.Trim();
+            if ClassId <> '' then
+                if not CustomerPostingGroup.Get(ClassId) then
+                    if Customer.Get(GPRM00101.CUSTNMBR) then
+                        if GPRM00201.Get(ClassId) then begin
+                            CustomerPostingGroup.Validate("Code", ClassId);
+                            CustomerPostingGroup.Validate("Description", GPRM00201.CLASDSCR);
+
+                            // Receivables Account
+                            AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMARACC);
+                            if AccountNumber <> '' then begin
+                                HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
+                                CustomerPostingGroup.Validate("Receivables Account", AccountNumber);
+                            end;
+
+                            // Payment Disc. Debit Acc.
+                            AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMTAKACC);
+                            if AccountNumber <> '' then begin
+                                HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
+                                CustomerPostingGroup.Validate("Payment Disc. Debit Acc.", AccountNumber);
+                            end;
+
+                            // Additional Fee Account
+                            AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMFCGACC);
+                            if AccountNumber <> '' then begin
+                                HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
+                                CustomerPostingGroup.Validate("Additional Fee Account", AccountNumber);
+                            end;
+
+                            // Payment Disc. Credit Acc.
+                            AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMAVACC);
+                            if AccountNumber <> '' then begin
+                                HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
+                                CustomerPostingGroup.Validate("Payment Disc. Credit Acc.", AccountNumber);
+                            end;
+
+                            // Payment Tolerance Debit Acc.
+                            // Payment Tolerance Credit Acc.
+                            AccountNumber := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMWRACC);
+                            if AccountNumber <> '' then begin
+                                HelperFunctions.EnsureAccountHasGenProdPostingAccount(AccountNumber);
+                                CustomerPostingGroup.Validate("Payment Tolerance Debit Acc.", AccountNumber);
+                                CustomerPostingGroup.Validate("Payment Tolerance Credit Acc.", AccountNumber);
+                            end;
+
+                            CustomerPostingGroup.Insert();
+
+                            Customer.Validate("Customer Posting Group", ClassId);
+                            Customer.Modify(true);
+                        end;
+        until GPRM00101.Next() = 0;
+    end;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
@@ -383,7 +383,7 @@ codeunit 4018 "GP Customer Migrator"
         CustomerPostingGroup: Record "Customer Posting Group";
         Customer: Record Customer;
         HelperFunctions: Codeunit "Helper Functions";
-        ClassId: Text[11];
+        ClassId: Text[20];
         AccountNumber: Code[20];
         MigrateCustomerClasses: Boolean;
     begin

--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPRM00101.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPRM00101.Table.al
@@ -1,0 +1,429 @@
+table 40114 "GP RM00101"
+{
+    Description = 'RM Customer Master';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; CUSTNMBR; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; CUSTNAME; Text[65])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(3; CUSTCLAS; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(4; CPRCSTNM; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(5; CNTCPRSN; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(6; STMTNAME; Text[65])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(7; SHRTNAME; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(8; ADRSCODE; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(9; UPSZONE; Text[3])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(10; SHIPMTHD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(11; TAXSCHID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(12; ADDRESS1; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(13; ADDRESS2; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(14; ADDRESS3; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(15; COUNTRY; Text[61])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(16; CITY; Text[35])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(17; STATE; Text[29])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(18; ZIP; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(19; PHONE1; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(20; PHONE2; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(21; PHONE3; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(22; FAX; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(23; PRBTADCD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(24; PRSTADCD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(25; STADDRCD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(26; SLPRSNID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(27; CHEKBKID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(28; PYMTRMID; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(29; CRLMTTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(30; CRLMTAMT; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(31; CRLMTPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(32; CRLMTPAM; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(33; CURNCYID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(34; RATETPID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(35; CUSTDISC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(36; PRCLEVEL; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(37; MINPYTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(38; MINPYDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(39; MINPYPCT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(40; FNCHATYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(41; FNCHPCNT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(42; FINCHDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(43; MXWOFTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(44; MXWROFAM; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(45; COMMENT1; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(46; COMMENT2; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(47; USERDEF1; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(48; USERDEF2; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(49; TAXEXMT1; Text[25])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(50; TAXEXMT2; Text[25])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(51; TXRGNNUM; Text[25])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(52; BALNCTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(53; STMTCYCL; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(54; BANKNAME; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(55; BNKBRNCH; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(56; SALSTERR; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(57; DEFCACTY; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(58; RMCSHACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(59; RMARACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(60; RMSLSACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(61; RMIVACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(62; RMCOSACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(63; RMTAKACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(64; RMAVACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(65; RMFCGACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(66; RMWRACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(67; RMSORACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(68; FRSTINDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(69; INACTIVE; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(70; HOLD; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(71; CRCARDID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(72; CRCRDNUM; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(73; CCRDXPDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(74; KPDSTHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(75; KPCALHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(76; KPERHIST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(77; KPTRXHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(78; NOTEINDX; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(79; CREATDDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(80; MODIFDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(81; Revalue_Customer; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(82; Post_Results_To; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(83; FINCHID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(84; GOVCRPID; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(85; GOVINDID; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(86; DISGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(87; DUEGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(88; DOCFMTID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(89; Send_Email_Statements; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(90; USERLANG; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(91; GPSFOINTEGRATIONID; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(92; INTEGRATIONSOURCE; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(93; INTEGRATIONID; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(94; ORDERFULFILLDEFAULT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(95; CUSTPRIORITY; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(96; CCode; Text[7])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(97; DECLID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(98; RMOvrpymtWrtoffAcctIdx; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(99; SHIPCOMPLETE; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(100; CBVAT; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(101; INCLUDEINDP; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(102; DEX_ROW_TS; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(103; DEX_ROW_ID; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+    keys
+    {
+        key(Key1; CUSTNMBR)
+        {
+            Clustered = true;
+        }
+    }
+}
+

--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPRM00201.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPRM00201.Table.al
@@ -1,0 +1,257 @@
+table 40115 "GP RM00201"
+{
+    Description = 'RM Class Master';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; CLASSID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; CLASDSCR; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(3; CRLMTTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(4; CRLMTAMT; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(5; CRLMTPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(6; CRLMTPAM; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(7; DEFLTCLS; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(8; BALNCTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(9; CHEKBKID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(10; BANKNAME; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(11; TAXSCHID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(12; SHIPMTHD; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(13; PYMTRMID; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(14; CUSTDISC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(15; CSTPRLVL; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(16; MINPYTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(17; MINPYDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(18; MINPYPCT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(19; MXWOFTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(20; MXWROFAM; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(21; FINCHARG; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(22; FNCHATYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(23; FINCHDLR; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(24; FNCHPCNT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(25; PRCLEVEL; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(26; CURNCYID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(27; RATETPID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(28; DEFCACTY; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(29; RMCSHACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(30; RMARACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(31; RMCOSACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(32; RMIVACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(33; RMSLSACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(34; RMAVACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(35; RMTAKACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(36; RMFCGACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(37; RMWRACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(38; RMSORACC; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(39; SALSTERR; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(40; SLPRSNID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(41; STMTCYCL; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(42; SNDSTMNT; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(43; INACTIVE; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(44; KPCALHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(45; KPDSTHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(46; KPERHIST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(47; KPTRXHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(48; NOTEINDX; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(49; MODIFDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(50; CREATDDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(51; Revalue_Customer; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(52; Post_Results_To; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(53; DISGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(54; DUEGRPER; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(55; ORDERFULFILLDEFAULT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(56; CUSTPRIORITY; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(57; RMOvrpymtWrtoffAcctIdx; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(58; CBVAT; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(59; INCLUDEINDP; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(60; DEX_ROW_ID; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+    keys
+    {
+        key(Key1; CLASSID)
+        {
+            Clustered = true;
+        }
+    }
+}
+

--- a/Apps/W1/HybridGP/app/src/Migration/Support/GPConfiguration.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/GPConfiguration.table.al
@@ -97,4 +97,15 @@ table 4024 "GP Configuration"
             Insert();
         end;
     end;
+
+    procedure IsAllPostMigrationDataCreated(): Boolean
+    begin
+        exit(
+                "CheckBooks Created" and
+                "Open Purchase Orders Created" and
+                "Fiscal Periods Created" and
+                "Vendor EFT Bank Acc. Created" and
+                "Customer Classes Created"
+            );
+    end;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Support/GPConfiguration.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/GPConfiguration.table.al
@@ -74,6 +74,11 @@ table 4024 "GP Configuration"
             DataClassification = SystemMetadata;
             InitValue = false;
         }
+        field(17; "Customer Classes Created"; Boolean)
+        {
+            DataClassification = SystemMetadata;
+            InitValue = false;
+        }
     }
 
     keys

--- a/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
@@ -1919,6 +1919,8 @@ Codeunit 4037 "Helper Functions"
     end;
 
     procedure CreatePostMigrationData(): Boolean
+    var
+        GPConfiguration: Record "GP Configuration";
     begin
         // this procedure might run multiple times depending upon migration errors.
 
@@ -1937,10 +1939,7 @@ Codeunit 4037 "Helper Functions"
         if not CustomerClassesCreated() then
             CreateCustomerClasses();
 
-        if CheckBooksCreated() and OpenPurchaseOrdersCreated() and FiscalPeriodsCreated() and VendorEFTBankAccountsCreated() and CustomerClassesCreated() then
-            exit(true);
-
-        exit(false);
+        exit(GPConfiguration.IsAllPostMigrationDataCreated());
     end;
 
     procedure CheckMigrationStatus()

--- a/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
@@ -46,6 +46,8 @@ codeunit 4025 "GP Cloud Migration"
         GPCM20600Lbl: Label 'CM20600', Locked = true;
         GPMC40200Lbl: Label 'MC40200', Locked = true;
         GPSY06000Lbl: Label 'SY06000', Locked = true;
+        GPRM00101Lbl: Label 'RM00101', Locked = true;
+        GPRM00201Lbl: Label 'RM00201', Locked = true;
 
     local procedure InitiateGPMigration()
     var
@@ -148,6 +150,8 @@ codeunit 4025 "GP Cloud Migration"
         UpdateOrInsertRecord(Database::"GP CM20600", GPCM20600Lbl);
         UpdateOrInsertRecord(Database::"GP MC40200", GPMC40200Lbl);
         UpdateOrInsertRecord(Database::"GP SY06000", GPSY06000Lbl);
+        UpdateOrInsertRecord(Database::"GP RM00101", GPRM00101Lbl);
+        UpdateOrInsertRecord(Database::"GP RM00201", GPRM00201Lbl);
     end;
 
     local procedure UpdateOrInsertRecord(TableID: Integer; SourceTableName: Text[128])

--- a/Apps/W1/HybridGP/app/src/pages/GPMigrationSettingsList.page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPMigrationSettingsList.page.al
@@ -73,6 +73,27 @@ page 4021 "GP Migration Settings List"
                         end;
                     end;
                 }
+                field("Migrate Customer Classes"; MigrateCustomerClasses)
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Migrate Customer Classes';
+                    ToolTip = 'Specifies whether to migrate Customer Classes.';
+                    Width = 8;
+
+                    trigger OnValidate()
+                    var
+                        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+                    begin
+                        if not GPCompanyAdditionalSettings.Get(Rec.Name) then begin
+                            GPCompanyAdditionalSettings.Name := Rec.Name;
+                            GPCompanyAdditionalSettings."Migrate Customer Classes" := MigrateCustomerClasses;
+                            GPCompanyAdditionalSettings.Insert();
+                        end else begin
+                            GPCompanyAdditionalSettings."Migrate Customer Classes" := MigrateCustomerClasses;
+                            GPCompanyAdditionalSettings.Modify();
+                        end;
+                    end;
+                }
             }
         }
     }
@@ -95,8 +116,10 @@ page 4021 "GP Migration Settings List"
         Rec.Modify();
 
         MigrateInactiveCheckbooks := GPCompanyAdditionalSettings.GetMigrateInactiveCheckbooks();
+        MigrateCustomerClasses := GPCompanyAdditionalSettings.GetMigrateCustomerClasses();
     end;
 
     var
         MigrateInactiveCheckbooks: Boolean;
+        MigrateCustomerClasses: Boolean;
 }

--- a/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
+++ b/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
@@ -17,6 +17,11 @@ table 40105 "GP Company Additional Settings"
             InitValue = true;
             DataClassification = SystemMetadata;
         }
+        field(12; "Migrate Customer Classes"; Boolean)
+        {
+            InitValue = true;
+            DataClassification = SystemMetadata;
+        }
     }
 
     keys
@@ -36,5 +41,16 @@ table 40105 "GP Company Additional Settings"
             MigrateInactiveCheckbooks := Rec."Migrate Inactive Checkbooks";
 
         exit(MigrateInactiveCheckbooks);
+    end;
+
+    procedure GetMigrateCustomerClasses(): Boolean
+    var
+        MigrateCustomerClasses: Boolean;
+    begin
+        MigrateCustomerClasses := true;
+        if Rec.Get(CompanyName()) then
+            MigrateCustomerClasses := Rec."Migrate Customer Classes";
+
+        exit(MigrateCustomerClasses);
     end;
 }


### PR DESCRIPTION
This change enhances the GP cloud migration to include migrating GP Customer Classes to BC Customer Posting Groups.

- For each GP customer class that has related accounts a new Customer Posting Group will be created in BC.
- Any customer migrated from GP that is part of a customer class will have the related Customer Posting Group assigned.  