### PR TITLE
Migrate Item Classes

### DIFF
--- a/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
@@ -67,9 +67,11 @@ permissionset 4031 "HybridGP - Edit"
                     tabledata "GP Migration Errors" = IMD,
                     tabledata "GP Segment Name" = IMD,
                     tabledata "GP Company Additional Settings" = IMD,
-                    tabledata "GP SY40100" = RIMD,
-                    tabledata "GP SY40101" = RIMD,
-                    tabledata "GP CM20600" = RIMD,
+                    tabledata "GP SY40100" = IMD,
+                    tabledata "GP SY40101" = IMD,
+                    tabledata "GP CM20600" = IMD,
                     tabledata "GP MC40200" = IMD,
-                    tabledata "GP SY06000" = IMD;
+                    tabledata "GP SY06000" = IMD,
+                    tabledata "GP IV00101" = IMD,
+                    tabledata "GP IV40400" = IMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
@@ -96,5 +96,7 @@ permissionset 4029 "HybridGP - Objects"
                     table "GP SY40101" = X,
                     table "GP CM20600" = X,
                     table "GP MC40200" = X,
-                    table "GP SY06000" = X;
+                    table "GP SY06000" = X,
+                    table "GP IV00101" = X,
+                    table "GP IV40400" = X;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
@@ -71,5 +71,7 @@ permissionset 4032 "HybridGP - Read"
                     tabledata "GP SY40101" = R,
                     tabledata "GP CM20600" = R,
                     tabledata "GP MC40200" = R,
-                    tabledata "GP SY06000" = R;
+                    tabledata "GP SY06000" = R,
+                    tabledata "GP IV00101" = R,
+                    tabledata "GP IV40400" = R;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
@@ -64,5 +64,7 @@ permissionsetextension 4025 "D365 BASIC - HGP" extends "D365 BASIC"
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP IV00101" = RIMD,
+                  tabledata "GP IV40400" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
@@ -64,5 +64,7 @@ permissionsetextension 4026 "D365 BASIC ISV - HGP" extends "D365 BASIC ISV"
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP IV00101" = RIMD,
+                  tabledata "GP IV40400" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
@@ -64,5 +64,7 @@ permissionsetextension 4027 "D365 TEAM MEMBER - HGP" extends "D365 TEAM MEMBER"
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP IV00101" = RIMD,
+                  tabledata "GP IV40400" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/intelligentcloudHGP.permisisonsetextension.al
+++ b/Apps/W1/HybridGP/app/Permissions/intelligentcloudHGP.permisisonsetextension.al
@@ -64,5 +64,7 @@ permissionsetextension 4028 "INTELLIGENT CLOUD - HGP" extends "INTELLIGENT CLOUD
                   tabledata "GP Checkbook MSTR" = RIMD,
                   tabledata "GP Checkbook Transactions" = RIMD,
                   tabledata "GP MC40200" = RIMD,
-                  tabledata "GP SY06000" = RIMD;
+                  tabledata "GP SY06000" = RIMD,
+                  tabledata "GP IV00101" = RIMD,
+                  tabledata "GP IV40400" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Items/GPIV00101.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Items/GPIV00101.Table.al
@@ -1,0 +1,377 @@
+table 40116 "GP IV00101"
+{
+    Description = 'Item Master';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; ITEMNMBR; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; ITEMDESC; Text[101])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(3; NOTEINDX; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(4; ITMSHNAM; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(5; ITEMTYPE; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(6; ITMGEDSC; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(7; STNDCOST; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(8; CURRCOST; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(9; ITEMSHWT; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(10; DECPLQTY; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(11; DECPLCUR; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(12; ITMTSHID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(13; TAXOPTNS; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(14; IVIVINDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(15; IVIVOFIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(16; IVCOGSIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(17; IVSLSIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(18; IVSLDSIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(19; IVSLRNIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(20; IVINUSIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(21; IVINSVIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(22; IVDMGIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(23; IVVARIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(24; DPSHPIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(25; PURPVIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(26; UPPVIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(27; IVRETIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(28; ASMVRIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(29; ITMCLSCD; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(30; ITMTRKOP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(31; LOTTYPE; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(32; KPERHIST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(33; KPTRXHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(34; KPCALHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(35; KPDSTHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(36; ALWBKORD; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(37; VCTNMTHD; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(38; UOMSCHDL; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(39; ALTITEM1; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(40; ALTITEM2; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(41; USCATVLS_1; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(42; USCATVLS_2; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(43; USCATVLS_3; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(44; USCATVLS_4; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(45; USCATVLS_5; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(46; USCATVLS_6; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(47; MSTRCDTY; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(48; MODIFDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(49; CREATDDT; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(50; WRNTYDYS; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(51; PRCLEVEL; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(52; LOCNCODE; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(53; PINFLIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(54; PURMCIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(55; IVINFIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(56; INVMCIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(57; CGSINFLX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(58; CGSMCIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(59; ITEMCODE; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(60; TCC; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(61; PriceGroup; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(62; PRICMTHD; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(63; PRCHSUOM; Text[9])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(64; SELNGUOM; Text[9])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(65; KTACCTSR; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(66; LASTGENSN; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(67; ABCCODE; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(68; Revalue_Inventory; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(69; Tolerance_Percentage; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(70; Purchase_Item_Tax_Schedu; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(71; Purchase_Tax_Options; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(72; ITMPLNNNGTYP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(73; STTSTCLVLPRCNTG; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(74; CNTRYORGN; Text[7])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(75; INACTIVE; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(76; MINSHELF1; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(77; MINSHELF2; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(78; INCLUDEINDP; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(79; LOTEXPWARN; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(80; LOTEXPWARNDAYS; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(81; LASTGENLOT; Text[21])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(82; Lot_Split_Quantity; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(83; UseQtyOverageTolerance; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(84; UseQtyShortageTolerance; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(85; QtyOverTolerancePercent; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(86; QtyShortTolerancePercent; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(87; IVSCRVIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(88; USERID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(89; DEX_ROW_TS; DateTime)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(90; DEX_ROW_ID; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+    keys
+    {
+        key(Key1; ITEMNMBR)
+        {
+            Clustered = true;
+        }
+    }
+}
+

--- a/Apps/W1/HybridGP/app/src/Migration/Items/GPIV40400.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Items/GPIV40400.Table.al
@@ -1,0 +1,249 @@
+table 40117 "GP IV40400"
+{
+    Description = 'Item Class Setup';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; ITMCLSCD; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; ITMCLSDC; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(3; DEFLTCLS; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(4; NOTEINDX; Decimal)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(5; ITEMTYPE; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(6; ITMTRKOP; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(7; LOTTYPE; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(8; KPERHIST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(9; KPTRXHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(10; KPCALHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(11; KPDSTHST; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(12; ALWBKORD; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(13; ITMGEDSC; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(14; TAXOPTNS; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(15; ITMTSHID; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(16; Purchase_Tax_Options; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(17; Purchase_Item_Tax_Schedu; Text[15])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(18; UOMSCHDL; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(19; VCTNMTHD; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(20; USCATVLS_1; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(21; USCATVLS_2; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(22; USCATVLS_3; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(23; USCATVLS_4; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(24; USCATVLS_5; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(25; USCATVLS_6; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(26; DECPLQTY; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(27; IVIVINDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(28; IVIVOFIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(29; IVCOGSIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(30; IVSLSIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(31; IVSLDSIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(32; IVSLRNIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(33; IVINUSIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(34; IVINSVIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(35; IVDMGIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(36; IVVARIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(37; DPSHPIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(38; PURPVIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(39; UPPVIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(40; IVRETIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(41; ASMVRIDX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(42; PRCLEVEL; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(43; PriceGroup; Text[11])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(44; PRICMTHD; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(45; TCC; Text[31])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(46; Revalue_Inventory; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(47; Tolerance_Percentage; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(48; CNTRYORGN; Text[7])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(49; STTSTCLVLPRCNTG; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(50; INCLUDEINDP; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(51; LOTEXPWARN; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(52; LOTEXPWARNDAYS; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(53; UseQtyOverageTolerance; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(54; UseQtyShortageTolerance; Boolean)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(55; QtyOverTolerancePercent; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(56; QtyShortTolerancePercent; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(57; IVSCRVIX; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(58; DEX_ROW_ID; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+    keys
+    {
+        key(Key1; ITMCLSCD)
+        {
+            Clustered = true;
+        }
+    }
+}
+

--- a/Apps/W1/HybridGP/app/src/Migration/Support/GPConfiguration.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/GPConfiguration.table.al
@@ -74,6 +74,11 @@ table 4024 "GP Configuration"
             DataClassification = SystemMetadata;
             InitValue = false;
         }
+        field(18; "Item Classes Created"; Boolean)
+        {
+            DataClassification = SystemMetadata;
+            InitValue = false;
+        }
     }
 
     keys
@@ -91,5 +96,16 @@ table 4024 "GP Configuration"
             Init();
             Insert();
         end;
+    end;
+
+    procedure IsAllPostMigrationDataCreated(): Boolean
+    begin
+        exit(
+                "CheckBooks Created" and
+                "Open Purchase Orders Created" and
+                "Fiscal Periods Created" and
+                "Vendor EFT Bank Acc. Created" and
+                "Item Classes Created"
+            );
     end;
 }

--- a/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
@@ -46,6 +46,8 @@ codeunit 4025 "GP Cloud Migration"
         GPCM20600Lbl: Label 'CM20600', Locked = true;
         GPMC40200Lbl: Label 'MC40200', Locked = true;
         GPSY06000Lbl: Label 'SY06000', Locked = true;
+        GPIV00101Lbl: Label 'IV00101', Locked = true;
+        GPIV40400Lbl: Label 'IV40400', Locked = true;
 
     local procedure InitiateGPMigration()
     var
@@ -148,6 +150,8 @@ codeunit 4025 "GP Cloud Migration"
         UpdateOrInsertRecord(Database::"GP CM20600", GPCM20600Lbl);
         UpdateOrInsertRecord(Database::"GP MC40200", GPMC40200Lbl);
         UpdateOrInsertRecord(Database::"GP SY06000", GPSY06000Lbl);
+        UpdateOrInsertRecord(Database::"GP IV00101", GPIV00101Lbl);
+        UpdateOrInsertRecord(Database::"GP IV40400", GPIV40400Lbl);
     end;
 
     local procedure UpdateOrInsertRecord(TableID: Integer; SourceTableName: Text[128])

--- a/Apps/W1/HybridGP/app/src/pages/GPMigrationSettingsList.page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPMigrationSettingsList.page.al
@@ -73,6 +73,27 @@ page 4021 "GP Migration Settings List"
                         end;
                     end;
                 }
+                field("Migrate Item Classes"; MigrateItemClasses)
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Migrate Item Classes';
+                    ToolTip = 'Specifies whether to migrate Item Classes.';
+                    Width = 8;
+
+                    trigger OnValidate()
+                    var
+                        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+                    begin
+                        if not GPCompanyAdditionalSettings.Get(Rec.Name) then begin
+                            GPCompanyAdditionalSettings.Name := Rec.Name;
+                            GPCompanyAdditionalSettings."Migrate Item Classes" := MigrateItemClasses;
+                            GPCompanyAdditionalSettings.Insert();
+                        end else begin
+                            GPCompanyAdditionalSettings."Migrate Item Classes" := MigrateItemClasses;
+                            GPCompanyAdditionalSettings.Modify();
+                        end;
+                    end;
+                }
             }
         }
     }
@@ -95,8 +116,10 @@ page 4021 "GP Migration Settings List"
         Rec.Modify();
 
         MigrateInactiveCheckbooks := GPCompanyAdditionalSettings.GetMigrateInactiveCheckbooks();
+        MigrateItemClasses := GPCompanyAdditionalSettings.GetMigrateItemClasses();
     end;
 
     var
         MigrateInactiveCheckbooks: Boolean;
+        MigrateItemClasses: Boolean;
 }

--- a/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
+++ b/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
@@ -17,6 +17,11 @@ table 40105 "GP Company Additional Settings"
             InitValue = true;
             DataClassification = SystemMetadata;
         }
+        field(13; "Migrate Item Classes"; Boolean)
+        {
+            InitValue = true;
+            DataClassification = SystemMetadata;
+        }
     }
 
     keys
@@ -36,5 +41,16 @@ table 40105 "GP Company Additional Settings"
             MigrateInactiveCheckbooks := Rec."Migrate Inactive Checkbooks";
 
         exit(MigrateInactiveCheckbooks);
+    end;
+
+    procedure GetMigrateItemClasses(): Boolean
+    var
+        MigrateItemClasses: Boolean;
+    begin
+        MigrateItemClasses := true;
+        if Rec.Get(CompanyName()) then
+            MigrateItemClasses := Rec."Migrate Item Classes";
+
+        exit(MigrateItemClasses);
     end;
 }


### PR DESCRIPTION
This change enhances the GP cloud migration to include migrating GP Item Classes to BC Inventory Posting Groups.

- For each GP item class that has related accounts a new Inventory Posting Group will be created in BC.
- Any item migrated from GP that is part of an item class will have the related Inventory Posting Group assigned.  