### PR TITLE
Feature update document number

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Accounts/GPAccountMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Accounts/GPAccountMigrator.codeunit.al
@@ -99,7 +99,7 @@ codeunit 4017 "GP Account Migrator"
         GenJournalLine: Record "Gen. Journal Line";
         GPFiscalPeriods: Record "GP Fiscal Periods";
         Sender: Codeunit "Data Migration Facade Helper";
-        PostingGroupCode: Text;
+        PostingGroupCode: Code[10];
         DimSetID: Integer;
     begin
         GPGLTransactions.Reset();
@@ -113,8 +113,8 @@ codeunit 4017 "GP Account Migrator"
                     Sender.CreateGeneralJournalBatchIfNeeded(CopyStr(PostingGroupCode, 1, 10), '', '');
                     Sender.CreateGeneralJournalLine(
                         GenJournalLine,
-                        CopyStr(PostingGroupCode, 1, 10),
-                        CopyStr(GlDocNoTxt, 1, 20),
+                        PostingGroupCode,
+                        PostingGroupCode,
                         CopyStr(DescriptionTrxTxt, 1, 50),
                         GenJournalLine."Account Type"::"G/L Account",
                         CopyStr(GPAccount.AcctNum, 1, 20),

--- a/Apps/W1/HybridGP/app/src/Migration/Accounts/GPAccountMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Accounts/GPAccountMigrator.codeunit.al
@@ -6,7 +6,6 @@ codeunit 4017 "GP Account Migrator"
         PostingGroupCodeTxt: Label 'GP', Locked = true;
         PostingGroupDescriptionTxt: Label 'Migrated from GP', Locked = true;
         DescriptionTrxTxt: Label 'Migrated transaction', Locked = true;
-        GlDocNoTxt: Label 'G00001', Locked = true;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"GL Acc. Data Migration Facade", 'OnMigrateGlAccount', '', true, true)]
     procedure OnMigrateGlAccount(VAR Sender: Codeunit "GL Acc. Data Migration Facade"; RecordIdToMigrate: RecordId)


### PR DESCRIPTION
Currently the migration tool brings across all monthly summary transactions and assigns them all the same document number: G00001.  This number can make it difficult when trying to reconcile with GP.

Switch to use the Batch Name value for Document No. This means document number will be unique across batches, but each transaction within a particular batch will still have the same document number.