### PR TITLE
Create Last Reconciled Balance journal entry.

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Support/CheckBooks/GPCheckbookMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/CheckBooks/GPCheckbookMigrator.codeunit.al
@@ -3,7 +3,7 @@ codeunit 40025 "GP Checkbook Migrator"
     var
         BatchNameTxt: Label 'GPBANK', Locked = true;
         BankWarningTxt: Label 'Unable to get %1 posting account.', Comment = '%1 = Posting Group', Locked = true;
-        DescriptionTxt: Label 'Last Reconciled Balance Amount';
+        DescriptionTxt: Label 'Last GP Reconciled Balance Amount';
 
     procedure MoveCheckbookStagingData()
     var


### PR DESCRIPTION
Currently, the migration tool is not bringing over a beginning balance. Since we only bring over unreconciled transactions this can leave the current bank balance incorrect when comparing back to GP. 

To reconcile this, we need to create a general journal containing GP's last reconciled balance value. This will create the beginning balance for an account.