### PR TITLE
Update for multiple Remit To feature

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -141,7 +141,6 @@ codeunit 4022 "GP Vendor Migrator"
     local procedure MigrateVendorDetails(GPVendor: Record "GP Vendor"; VendorDataMigrationFacade: Codeunit "Vendor Data Migration Facade")
     var
         CompanyInformation: Record "Company Information";
-        GPVendorAddress: Record "GP Vendor Address";
         PaymentTermsFormula: DateFormula;
         VendorName: Text[50];
         ContactName: Text[50];
@@ -212,11 +211,10 @@ codeunit 4022 "GP Vendor Migrator"
         if GPVendorAddress.FindSet() then
             repeat
                 AddressCode := CopyStr(GPVendorAddress.ADRSCODE, 1, MaxStrLen(AddressCode));
-                if AddressCode = AddressCodeRemitToTxt then begin
+                if AddressCode = AddressCodeRemitToTxt then
                     CreateOrUpdateRemitAddress(Vendor, GPVendorAddress, AddressCode)
-                end else begin
-                    CreateOrUpdateOrderAddress(Vendor, GPVendorAddress, AddressCode)
-                end;
+                else
+                    CreateOrUpdateOrderAddress(Vendor, GPVendorAddress, AddressCode);
             until GPVendorAddress.Next() = 0;
     end;
 

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/tab4049.GPVendorAddress.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/tab4049.GPVendorAddress.al
@@ -54,33 +54,4 @@ table 4049 "GP Vendor Address"
             Clustered = true;
         }
     }
-
-    procedure MoveStagingData()
-    var
-        OrderAddress: Record "Order Address";
-        Vendor: Record Vendor;
-        HelperFunctions: Codeunit "Helper Functions";
-        Exists: Boolean;
-    begin
-        if Vendor.Get(VENDORID) then begin
-            Exists := OrderAddress.Get(VENDORID, CopyStr(ADRSCODE, 1, 10));
-            OrderAddress.Init();
-            OrderAddress."Vendor No." := VENDORID;
-            OrderAddress.Code := CopyStr(ADRSCODE, 1, 10);
-            OrderAddress.Name := Vendor.Name;
-            OrderAddress.Address := ADDRESS1;
-            OrderAddress."Address 2" := CopyStr(ADDRESS2, 1, 50);
-            OrderAddress.City := CopyStr(CITY, 1, 30);
-            OrderAddress.Contact := VNDCNTCT;
-            OrderAddress."Phone No." := HelperFunctions.CleanGPPhoneOrFaxNumber(PHNUMBR1);
-            OrderAddress."Fax No." := HelperFunctions.CleanGPPhoneOrFaxNumber(FAXNUMBR);
-            OrderAddress."Post Code" := ZIPCODE;
-            OrderAddress.County := STATE;
-
-            if not Exists then
-                OrderAddress.Insert()
-            else
-                OrderAddress.Modify();
-        end;
-    end;
 }


### PR DESCRIPTION
As part of release 21 for Business Central they will be adding the Multiple Remit To feature that will allow vendors to have more than one Remit to Address.  Because of this change we need to update the GP Migration tool to do the following.

- We will NO LONGER migrate the Address ID found in the GP Remit to field to be the Vendors main address in BC.  The Primary Address in GP will be migrated to the Vendors main address.  (This is how the migration previously worked before version 20.1)
- The Address ID identified in the Remit To field in GP will be migrated to the Remit to Address table in BC (2224). 
- The remaining vendor addresses will be migrated to the BC Order Addresses just as they are now in the migration tool.  