### PR TITLE
Fix recent issues with POs

### DIFF
--- a/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
@@ -49,6 +49,8 @@ permissionset 4031 "HybridGP - Edit"
                     tabledata "GPSOPWorkflowWorkHist" = IMD,
 #pragma warning disable AL0432
                     tabledata "GPForecastTemp" = IMD,
+                    tabledata "GP POPPOHeader" = IMD,
+                    tabledata "GP POPPOLine" = IMD,
 #pragma warning restore AL0432
                     tabledata "GP Item" = IMD,
                     tabledata "GP Item Location" = IMD,
@@ -61,8 +63,6 @@ permissionset 4031 "HybridGP - Edit"
                     tabledata "GP Bank MSTR" = IMD,
                     tabledata "GP Checkbook MSTR" = IMD,
                     tabledata "GP Checkbook Transactions" = IMD,
-                    tabledata "GP POPPOHeader" = IMD,
-                    tabledata "GP POPPOLine" = IMD,
                     tabledata "GP Vendor" = IMD,
                     tabledata "GP Vendor Transactions" = IMD,
                     tabledata "GP Company Migration Settings" = IMD,
@@ -98,5 +98,7 @@ permissionset 4031 "HybridGP - Edit"
                     tabledata "GP SY00300" = IMD,
                     tabledata "GP SY01100" = IMD,
                     tabledata "GP SY01200" = IMD,
-                    tabledata "GP SY03300" = IMD;
+                    tabledata "GP SY03300" = IMD,
+                    tabledata "GP POP10100" = IMD,
+                    tabledata "GP POP10110" = IMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
@@ -61,6 +61,8 @@ permissionset 4029 "HybridGP - Objects"
                     codeunit "GP PO Migrator" = X,
 #pragma warning disable AL0432
                     table "GPForecastTemp" = X,
+                    table "GP POPPOHeader" = X,
+                    table "GP POPPOLine" = X,
 #pragma warning restore AL0432
                     page "GP Item" = X,
                     table "GP Item" = X,
@@ -81,8 +83,6 @@ permissionset 4029 "HybridGP - Objects"
                     table "GP Bank MSTR" = X,
                     table "GP Checkbook MSTR" = X,
                     table "GP Checkbook Transactions" = X,
-                    table "GP POPPOHeader" = X,
-                    table "GP POPPOLine" = X,
                     codeunit "GP Intelligent Cloud Upgrade" = X,
                     page "GP Vendor" = X,
                     table "GP Vendor" = X,
@@ -124,5 +124,7 @@ permissionset 4029 "HybridGP - Objects"
                     table "GP SY00300" = X,
                     table "GP SY01100" = X,
                     table "GP SY01200" = X,
-                    table "GP SY03300" = X;
+                    table "GP SY03300" = X,
+                    table "GP POP10100" = X,
+                    table "GP POP10110" = X;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
@@ -49,6 +49,8 @@ permissionset 4032 "HybridGP - Read"
                     tabledata "GPSOPWorkflowWorkHist" = R,
 #pragma warning disable AL0432
                     tabledata "GPForecastTemp" = R,
+                    tabledata "GP POPPOHeader" = R,
+                    tabledata "GP POPPOLine" = R,
 #pragma warning restore AL0432
                     tabledata "GP Item" = R,
                     tabledata "GP Item Location" = R,
@@ -61,8 +63,6 @@ permissionset 4032 "HybridGP - Read"
                     tabledata "GP Bank MSTR" = R,
                     tabledata "GP Checkbook MSTR" = R,
                     tabledata "GP Checkbook Transactions" = R,
-                    tabledata "GP POPPOHeader" = R,
-                    tabledata "GP POPPOLine" = R,
                     tabledata "GP Vendor" = R,
                     tabledata "GP Vendor Transactions" = R,
                     tabledata "GP Company Migration Settings" = R,
@@ -98,5 +98,7 @@ permissionset 4032 "HybridGP - Read"
                     tabledata "GP SY00300" = R,
                     tabledata "GP SY01100" = R,
                     tabledata "GP SY01200" = R,
-                    tabledata "GP SY03300" = R;
+                    tabledata "GP SY03300" = R,
+                    tabledata "GP POP10100" = R,
+                    tabledata "GP POP10110" = R;
 }

--- a/Apps/W1/HybridGP/app/Permissions/INTELLIGENTCLOUDHGP.PermissionSetExt.al
+++ b/Apps/W1/HybridGP/app/Permissions/INTELLIGENTCLOUDHGP.PermissionSetExt.al
@@ -91,5 +91,7 @@ permissionsetextension 4028 "INTELLIGENT CLOUD - HGP" extends "INTELLIGENT CLOUD
                   tabledata "GP SY00300" = RIMD,
                   tabledata "GP SY01100" = RIMD,
                   tabledata "GP SY01200" = RIMD,
-                  tabledata "GP SY03300" = RIMD;
+                  tabledata "GP SY03300" = RIMD,
+                  tabledata "GP POP10100" = RIMD,
+                  tabledata "GP POP10110" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
@@ -91,5 +91,7 @@ permissionsetextension 4025 "D365 BASIC - HGP" extends "D365 BASIC"
                   tabledata "GP SY00300" = RIMD,
                   tabledata "GP SY01100" = RIMD,
                   tabledata "GP SY01200" = RIMD,
-                  tabledata "GP SY03300" = RIMD;
+                  tabledata "GP SY03300" = RIMD,
+                  tabledata "GP POP10100" = RIMD,
+                  tabledata "GP POP10110" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
@@ -91,5 +91,7 @@ permissionsetextension 4026 "D365 BASIC ISV - HGP" extends "D365 BASIC ISV"
                   tabledata "GP SY00300" = RIMD,
                   tabledata "GP SY01100" = RIMD,
                   tabledata "GP SY01200" = RIMD,
-                  tabledata "GP SY03300" = RIMD;
+                  tabledata "GP SY03300" = RIMD,
+                  tabledata "GP POP10100" = RIMD,
+                  tabledata "GP POP10110" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
@@ -91,5 +91,7 @@ permissionsetextension 4027 "D365 TEAM MEMBER - HGP" extends "D365 TEAM MEMBER"
                   tabledata "GP SY00300" = RIMD,
                   tabledata "GP SY01100" = RIMD,
                   tabledata "GP SY01200" = RIMD,
-                  tabledata "GP SY03300" = RIMD;
+                  tabledata "GP SY03300" = RIMD,
+                  tabledata "GP POP10100" = RIMD,
+                  tabledata "GP POP10110" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
@@ -793,7 +793,7 @@ Codeunit 4037 "Helper Functions"
         GPPOPReceiptHist: Record "GPPOPReceiptHist"; //4116
         GPPOPPOHist: Record "GPPOPPOHist"; //4123
         GPPMHist: Record "GPPMHist"; //4126
-        GPPOPPOHeader: Record "GP POPPOHeader";
+        GPPOP10100: Record "GP POP10100";
         PaymentTerm: Text[22];
         PaymentTerm_New: Text[10];
     begin
@@ -865,10 +865,10 @@ Codeunit 4037 "Helper Functions"
                 if GPPMHist.FINDFIRST() then
                     GPPMHist.MODIFYALL(GPPMHist."PYMTRMID", PaymentTerm_New);
 
-                GPPOPPOHeader.Reset();
-                GPPOPPOHeader.SetRange(GPPOPPOHeader.PYMTRMID, PaymentTerm);
-                if GPPOPPOHeader.FindFirst() then
-                    GPPOPPOHeader.ModifyAll(GPPOPPOHeader.PYMTRMID, PaymentTerm_New);
+                GPPOP10100.Reset();
+                GPPOP10100.SetRange(GPPOP10100.PYMTRMID, PaymentTerm);
+                if GPPOP10100.FindFirst() then
+                    GPPOP10100.ModifyAll(GPPOP10100.PYMTRMID, PaymentTerm_New);
 
             end;
         until GPPaymentTerms.Next() = 0;
@@ -2004,5 +2004,22 @@ Codeunit 4037 "Helper Functions"
                 GLAccount."Gen. Prod. Posting Group" := PostingGroupCodeTxt;
                 GLAccount.Modify(true);
             end;
+    end;
+
+    procedure CreateCurrencyIfNeeded(CurrencyCode: Code[10])
+    var
+        Currency: Record Currency;
+        GPMC40200: Record "GP MC40200";
+    begin
+        if (CurrencyCode <> '') and not Currency.Get(CurrencyCode) then begin
+            GPMC40200.SetRange("CURNCYID", CurrencyCode);
+            if GPMC40200.FindFirst() then begin
+                Currency.Validate("Symbol", GPMC40200.CRNCYSYM);
+                Currency.Validate("Code", CurrencyCode);
+                Currency.Validate("Description", CopyStr(GPMC40200.CRNCYDSC, 1, 30));
+                Currency.Validate("Invoice Rounding Type", Currency."Invoice Rounding Type"::Nearest);
+                Currency.Insert();
+            end;
+        end;
     end;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOP10100.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOP10100.table.al
@@ -1,0 +1,139 @@
+table 40137 "GP POP10100"
+{
+    DataClassification = CustomerContent;
+    Extensible = false;
+
+    fields
+    {
+        field(1; PONUMBER; Text[18])
+        {
+            Caption = 'PONUMBER';
+            DataClassification = CustomerContent;
+        }
+        field(2; POSTATUS; Option)
+        {
+            Caption = 'POSTATUS';
+            OptionMembers = ,"New","Released","Change Order","Received","Closed","Canceled";
+            DataClassification = CustomerContent;
+        }
+        field(3; STATGRP; Integer)
+        {
+            Caption = 'STATGRP';
+            DataClassification = CustomerContent;
+        }
+        field(4; POTYPE; Option)
+        {
+            Caption = 'POTYPE';
+            OptionMembers = ,"Standard","Drop-Ship","Blanket","Drop-Ship Blanket";
+            DataClassification = CustomerContent;
+        }
+        field(7; DOCDATE; Date)
+        {
+            Caption = 'DOCDATE';
+            DataClassification = CustomerContent;
+        }
+        field(10; PRMDATE; Date)
+        {
+            Caption = 'PRMDATE';
+            DataClassification = CustomerContent;
+        }
+        field(14; SHIPMTHD; Text[16])
+        {
+            Caption = 'SHIPMTHD';
+            DataClassification = CustomerContent;
+        }
+        field(22; VENDORID; Text[16])
+        {
+            Caption = 'VENDORID';
+            DataClassification = CustomerContent;
+        }
+        field(28; PRSTADCD; Text[16])
+        {
+            Caption = 'PRSTADCD';
+            DataClassification = CustomerContent;
+        }
+        field(29; CMPNYNAM; Text[66])
+        {
+            Caption = 'CMPNYNAM';
+            DataClassification = CustomerContent;
+        }
+        field(30; CONTACT; Text[62])
+        {
+            Caption = 'CONTACT';
+            DataClassification = CustomerContent;
+        }
+        field(31; ADDRESS1; Text[62])
+        {
+            Caption = 'ADDRESS1';
+            DataClassification = CustomerContent;
+        }
+        field(32; ADDRESS2; Text[62])
+        {
+            Caption = 'ADDRESS2';
+            DataClassification = CustomerContent;
+        }
+        field(34; CITY; Text[36])
+        {
+            Caption = 'CITY';
+            DataClassification = CustomerContent;
+        }
+        field(35; STATE; Text[30])
+        {
+            Caption = 'STATE';
+            DataClassification = CustomerContent;
+        }
+        field(36; ZIPCODE; Text[12])
+        {
+            Caption = 'ZIPCODE';
+            DataClassification = CustomerContent;
+        }
+        field(38; COUNTRY; Text[62])
+        {
+            Caption = 'COUNTRY';
+            DataClassification = CustomerContent;
+        }
+        field(43; PYMTRMID; Text[22])
+        {
+            Caption = 'PYMTRMID';
+            DataClassification = CustomerContent;
+        }
+        field(71; CURNCYID; Text[16])
+        {
+            Caption = 'CURNCYID';
+            DataClassification = CustomerContent;
+        }
+        field(72; CURRNIDX; Integer)
+        {
+            Caption = 'CURRNIDX';
+            DataClassification = CustomerContent;
+        }
+        field(73; RATETPID; Text[16])
+        {
+            Caption = 'RATETPID';
+            DataClassification = CustomerContent;
+        }
+        field(74; EXGTBLID; Text[16])
+        {
+            Caption = 'EXGTBLID';
+            DataClassification = CustomerContent;
+        }
+        field(75; XCHGRATE; Decimal)
+        {
+            Caption = 'XCHGRATE';
+            DataClassification = CustomerContent;
+        }
+        field(76; EXCHDATE; Date)
+        {
+            Caption = 'EXCHDATE';
+            DataClassification = CustomerContent;
+        }
+    }
+
+    keys
+    {
+        key(PK; PONUMBER)
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOP10110.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOP10110.table.al
@@ -1,0 +1,129 @@
+table 40138 "GP POP10110"
+{
+    DataClassification = CustomerContent;
+    Extensible = false;
+
+    fields
+    {
+        field(1; PONUMBER; Text[18])
+        {
+            Caption = 'PONUMBER';
+            DataClassification = CustomerContent;
+        }
+        field(2; ORD; Integer)
+        {
+            Caption = 'ORD';
+            DataClassification = CustomerContent;
+        }
+        field(3; POLNESTA; Option)
+        {
+            Caption = 'POLNESTA';
+            OptionMembers = ,"New","Released","Change Order","Received","Closed","Canceled";
+            DataClassification = CustomerContent;
+        }
+        field(4; POTYPE; Option)
+        {
+            Caption = 'POTYPE';
+            OptionMembers = ,"Standard","Drop-Ship","Blanket","Drop-Ship Blanket";
+            DataClassification = CustomerContent;
+        }
+        field(5; ITEMNMBR; Text[32])
+        {
+            Caption = 'ITEMNMBR';
+            DataClassification = CustomerContent;
+        }
+        field(6; ITEMDESC; Text[102])
+        {
+            Caption = 'ITEMDESC';
+            DataClassification = CustomerContent;
+        }
+        field(7; VENDORID; Text[16])
+        {
+            Caption = 'VENDORID';
+            DataClassification = CustomerContent;
+        }
+        field(10; NONINVEN; Integer)
+        {
+            Caption = 'NONINVEN';
+            DataClassification = CustomerContent;
+        }
+        field(11; LOCNCODE; Text[12])
+        {
+            Caption = 'LOCNCODE';
+            DataClassification = CustomerContent;
+        }
+        field(12; UOFM; Text[10])
+        {
+            Caption = 'UOFM';
+            DataClassification = CustomerContent;
+        }
+        field(14; QTYORDER; Decimal)
+        {
+            Caption = 'QTYORDER';
+            DataClassification = CustomerContent;
+        }
+        field(15; QTYCANCE; Decimal)
+        {
+            Caption = 'QTYCANCE';
+            DataClassification = CustomerContent;
+        }
+        field(18; UNITCOST; Decimal)
+        {
+            Caption = 'UNITCOST';
+            DataClassification = CustomerContent;
+        }
+        field(19; EXTDCOST; Decimal)
+        {
+            Caption = 'EXTDCOST';
+            DataClassification = CustomerContent;
+        }
+        field(20; INVINDX; Integer)
+        {
+            Caption = 'INVINDX';
+            DataClassification = CustomerContent;
+        }
+        field(21; REQDATE; Date)
+        {
+            Caption = 'REQDATE';
+            DataClassification = CustomerContent;
+        }
+        field(22; PRMDATE; Date)
+        {
+            Caption = 'PRMDATE';
+            DataClassification = CustomerContent;
+        }
+        field(40; BRKFLD1; Integer)
+        {
+            Caption = 'BRKFLD1';
+            DataClassification = CustomerContent;
+        }
+        field(47; CURNCYID; Text[16])
+        {
+            Caption = 'CURNCYID';
+            DataClassification = CustomerContent;
+        }
+        field(48; CURRNIDX; Integer)
+        {
+            Caption = 'CURRNIDX';
+            DataClassification = CustomerContent;
+        }
+        field(49; XCHGRATE; Decimal)
+        {
+            Caption = 'XCHGRATE';
+            DataClassification = CustomerContent;
+        }
+        field(50; RATECALC; Integer)
+        {
+            Caption = 'RATECALC';
+            DataClassification = CustomerContent;
+        }
+    }
+
+    keys
+    {
+        key(PK; PONUMBER, ORD, BRKFLD1)
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOPPOHeader.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOPPOHeader.table.al
@@ -1,7 +1,11 @@
+#if not CLEAN22
 table 40102 "GP POPPOHeader"
 {
     DataClassification = CustomerContent;
     Extensible = false;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'Replaced by table GP POP10100.';
+    ObsoleteTag = '22.0';
 
     fields
     {
@@ -856,3 +860,4 @@ table 40102 "GP POPPOHeader"
             PurchaseHeader."Ship-to County" := STATE;
     end;
 }
+#endif

--- a/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOPPOLine.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOPPOLine.table.al
@@ -1,7 +1,11 @@
+#if not CLEAN22
 table 40103 "GP POPPOLine"
 {
     DataClassification = CustomerContent;
     Extensible = false;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'Replaced by table GP POP10110.';
+    ObsoleteTag = '22.0';
 
     fields
     {
@@ -673,3 +677,4 @@ table 40103 "GP POPPOLine"
         end;
     end;
 }
+#endif

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -417,6 +417,7 @@ codeunit 4022 "GP Vendor Migrator"
         Vendor: Record Vendor;
         VendorBankAccount: Record "Vendor Bank Account";
         GeneralLedgerSetup: Record "General Ledger Setup";
+        HelperFunctions: Codeunit "Helper Functions";
         VendorBankAccountExists: Boolean;
         CurrencyCode: Code[10];
     begin
@@ -427,7 +428,7 @@ codeunit 4022 "GP Vendor Migrator"
         repeat
             if Vendor.Get(GPSY06000.CustomerVendor_ID) then begin
                 CurrencyCode := CopyStr(GPSY06000.CURNCYID, 1, MaxStrLen(CurrencyCode));
-                CreateCurrencyIfNeeded(CurrencyCode);
+                HelperFunctions.CreateCurrencyIfNeeded(CurrencyCode);
                 CreateSwiftCodeIfNeeded(GPSY06000.SWIFTADDR);
 
                 VendorBankAccountExists := VendorBankAccount.Get(Vendor."No.", GPSY06000.EFTBankCode);
@@ -452,23 +453,6 @@ codeunit 4022 "GP Vendor Migrator"
                 SetPreferredBankAccountIfNeeded(GPSY06000, Vendor);
             end;
         until GPSY06000.Next() = 0;
-    end;
-
-    local procedure CreateCurrencyIfNeeded(CurrencyCode: Code[10])
-    var
-        Currency: Record Currency;
-        GPMC40200: Record "GP MC40200";
-    begin
-        if (CurrencyCode <> '') and not Currency.Get(CurrencyCode) then begin
-            GPMC40200.SetRange("CURNCYID", CurrencyCode);
-            if GPMC40200.FindFirst() then begin
-                Currency.Validate("Symbol", GPMC40200.CRNCYSYM);
-                Currency.Validate("Code", CurrencyCode);
-                Currency.Validate("Description", CopyStr(GPMC40200.CRNCYDSC, 1, 30));
-                Currency.Validate("Invoice Rounding Type", Currency."Invoice Rounding Type"::Nearest);
-                Currency.Insert();
-            end;
-        end;
     end;
 
     local procedure CreateSwiftCodeIfNeeded(SWIFTADDR: Text[11])

--- a/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
@@ -212,8 +212,8 @@ codeunit 4025 "GP Cloud Migration"
         UpdateOrInsertRecord(Database::"GP PM20000", 'PM20000');
         UpdateOrInsertRecord(Database::GPPMHist, 'PM30200');
 
-        UpdateOrInsertRecord(Database::"GP POPPOHeader", 'POP10100');
-        UpdateOrInsertRecord(Database::"GP POPPOLine", 'POP10110');
+        UpdateOrInsertRecord(Database::"GP POP10100", 'POP10100');
+        UpdateOrInsertRecord(Database::"GP POP10110", 'POP10110');
         UpdateOrInsertRecord(Database::GPPOPReceiptApply, 'POP10500');
         UpdateOrInsertRecord(Database::GPPOPReceiptHist, 'POP30300');
         UpdateOrInsertRecord(Database::GPPOPReceiptLineHist, 'POP30310');


### PR DESCRIPTION
This change fixes a few issues with migrating open POs.

- Replaced the PO header and line tables. The new tables contain only fields that are used (or may be used in the near future), have the updated naming convention, and without the TIME1 field that was causing errors when a DateTime was included in that field.
- Added the PO filter that was missing after the SQL statements were removed.
- Added a missing .Init() statement when looping PO headers to insert.
- Fixed an issue where the originating currency wasn't migrated if it was in a non-default currency.