### PR TITLE
Vendor Name 2 logic update and some code cleanup.

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -147,54 +147,74 @@ codeunit 4022 "GP Vendor Migrator"
     local procedure MigrateVendorDetails(GPVendor: Record "GP Vendor"; VendorDataMigrationFacade: Codeunit "Vendor Data Migration Facade")
     var
         CompanyInformation: Record "Company Information";
+        Vendor: Record Vendor;
+        GenBusinessPostingGroup: Record "Gen. Business Posting Group";
+        VendorPostingGroup: Record "Vendor Posting Group";
         HelperFunctions: Codeunit "Helper Functions";
         PaymentTermsFormula: DateFormula;
-        VendorName: Text[50];
-        ContactName: Text[50];
+        VendorNo: Code[20];
         Country: Code[10];
+        ZipCode: Code[20];
+        ShipMethod: Code[10];
+        PaymentTerms: Code[10];
+        VendorName: Text[50];
+        VendorName2: Text[50];
+        ContactName: Text[50];
+        Address1: Text[50];
+        Address2: Text[50];
+        City: Text[30];
+        State: Text[30];
     begin
-        VendorName := CopyStr(GPVendor.VENDNAME, 1, 50);
-        ContactName := CopyStr(GPVendor.VNDCNTCT, 1, 50);
-        if not VendorDataMigrationFacade.CreateVendorIfNeeded(CopyStr(GPVendor.VENDORID, 1, 20), VendorName) then
+        VendorNo := CopyStr(GPVendor.VENDORID, 1, MaxStrLen(Vendor."No."));
+        VendorName := CopyStr(GPVendor.VENDNAME.TrimEnd(), 1, MaxStrLen(VendorName));
+
+        if not VendorDataMigrationFacade.CreateVendorIfNeeded(VendorNo, VendorName) then
             exit;
 
-        if (CopyStr(GPVendor.COUNTRY, 1, 10) <> '') then begin
-            HelperFunctions.CreateCountryIfNeeded(CopyStr(GPVendor.COUNTRY, 1, 10), CopyStr(GPVendor.COUNTRY, 1, 10));
-            Country := CopyStr(GPVendor.COUNTRY, 1, 10);
-        end else begin
+        VendorName2 := CopyStr(GPVendor.VNDCHKNM.TrimEnd(), 1, MaxStrLen(VendorName2));
+        ContactName := CopyStr(GPVendor.VNDCNTCT, 1, MaxStrLen(ContactName));
+        Address1 := CopyStr(GPVendor.ADDRESS1, 1, MaxStrLen(Address1));
+        Address2 := CopyStr(GPVendor.ADDRESS2, 1, MaxStrLen(Address2));
+        City := CopyStr(GPVendor.CITY, 1, MaxStrLen(City));
+        State := CopyStr(GPVendor.STATE, 1, MaxStrLen(State));
+        ZipCode := CopyStr(GPVendor.ZIPCODE, 1, MaxStrLen(ZipCode));
+        Country := CopyStr(GPVendor.COUNTRY, 1, MaxStrLen(Country));
+        ShipMethod := CopyStr(GPVendor.SHIPMTHD, 1, MaxStrLen(ShipMethod));
+        PaymentTerms := CopyStr(GPVendor.PYMTRMID, 1, MaxStrLen(PaymentTerms));
+
+        if VendorName2 <> '' then
+            if VendorName2 <> VendorName then
+                VendorDataMigrationFacade.SetName2(VendorName2);
+
+        if (Country <> '') then
+            HelperFunctions.CreateCountryIfNeeded(Country, Country)
+        else begin
             CompanyInformation.Get();
             Country := CompanyInformation."Country/Region Code";
         end;
 
-        if (CopyStr(GPVendor.ZIPCODE, 1, 20) <> '') and (CopyStr(GPVendor.CITY, 1, 30) <> '') then
-            VendorDataMigrationFacade.CreatePostCodeIfNeeded(CopyStr(GPVendor.ZIPCODE, 1, 20),
-                CopyStr(GPVendor.CITY, 1, 30), CopyStr(GPVendor.STATE, 1, 20), Country);
+        if (ZipCode <> '') and (City <> '') then
+            VendorDataMigrationFacade.CreatePostCodeIfNeeded(ZipCode, City, State, Country);
 
-        VendorDataMigrationFacade.SetAddress(CopyStr(GPVendor.ADDRESS1, 1, 50),
-            CopyStr(GPVendor.ADDRESS2, 1, 50), Country,
-            CopyStr(GPVendor.ZIPCODE, 1, 20), CopyStr(GPVendor.CITY, 1, 30));
-
+        VendorDataMigrationFacade.SetAddress(Address1, Address2, Country, ZipCode, City);
         VendorDataMigrationFacade.SetPhoneNo(HelperFunctions.CleanGPPhoneOrFaxNumber(GPVendor.PHNUMBR1));
         VendorDataMigrationFacade.SetFaxNo(HelperFunctions.CleanGPPhoneOrFaxNumber(GPVendor.FAXNUMBR));
         VendorDataMigrationFacade.SetContact(ContactName);
-        VendorDataMigrationFacade.SetVendorPostingGroup(CopyStr(PostingGroupCodeTxt, 1, 5));
-        VendorDataMigrationFacade.SetGenBusPostingGroup(CopyStr(PostingGroupCodeTxt, 1, 5));
-        VendorDataMigrationFacade.SetEmail(COPYSTR(GPVendor.INET1, 1, 80));
-        VendorDataMigrationFacade.SetHomePage(COPYSTR(GPVendor.INET2, 1, 80));
-        VendorDataMigrationFacade.SetVendorPostingGroup(CopyStr(PostingGroupCodeTxt, 1, 5));
+        VendorDataMigrationFacade.SetVendorPostingGroup(CopyStr(PostingGroupCodeTxt, 1, MaxStrLen(VendorPostingGroup."Code")));
+        VendorDataMigrationFacade.SetGenBusPostingGroup(CopyStr(PostingGroupCodeTxt, 1, MaxStrLen(GenBusinessPostingGroup."Code")));
+        VendorDataMigrationFacade.SetEmail(COPYSTR(GPVendor.INET1, 1, MaxStrLen(Vendor."E-Mail")));
+        VendorDataMigrationFacade.SetHomePage(COPYSTR(GPVendor.INET2, 1, MaxStrLen(Vendor."Home Page")));
 
-        if (CopyStr(GPVendor.SHIPMTHD, 1, 10) <> '') then begin
-            VendorDataMigrationFacade.CreateShipmentMethodIfNeeded(CopyStr(GPVendor.SHIPMTHD, 1, 10), '');
-            VendorDataMigrationFacade.SetShipmentMethodCode(CopyStr(GPVendor.SHIPMTHD, 1, 10));
+        if (ShipMethod <> '') then begin
+            VendorDataMigrationFacade.CreateShipmentMethodIfNeeded(ShipMethod, '');
+            VendorDataMigrationFacade.SetShipmentMethodCode(ShipMethod);
         end;
 
-        if (CopyStr(GPVendor.PYMTRMID, 1, 10) <> '') then begin
+        if (PaymentTerms <> '') then begin
             EVALUATE(PaymentTermsFormula, '');
-            VendorDataMigrationFacade.CreatePaymentTermsIfNeeded(CopyStr(GPVendor.PYMTRMID, 1, 10), GPVendor.PYMTRMID, PaymentTermsFormula);
-            VendorDataMigrationFacade.SetPaymentTermsCode(CopyStr(GPVendor.PYMTRMID, 1, 10));
+            VendorDataMigrationFacade.CreatePaymentTermsIfNeeded(PaymentTerms, PaymentTerms, PaymentTermsFormula);
+            VendorDataMigrationFacade.SetPaymentTermsCode(PaymentTerms);
         end;
-
-        VendorDataMigrationFacade.SetName2(CopyStr(GPVendor.VNDCHKNM, 1, 50));
 
         if (GPVendor.TAXSCHID <> '') then begin
             VendorDataMigrationFacade.CreateTaxAreaIfNeeded(GPVendor.TAXSCHID, '');

--- a/Apps/W1/HybridGP/test/src/GPDataMigrationTests.codeunit.al
+++ b/Apps/W1/HybridGP/test/src/GPDataMigrationTests.codeunit.al
@@ -363,12 +363,13 @@ codeunit 139664 "GP Data Migration Tests"
         // [WHEN] data is migrated
         Vendor.DeleteAll();
         GPVendor.Reset();
+
         MigrateVendors(GPVendor);
 
-        // [then] Then the correct number of Vendors are applied
+        // [THEN] The correct number of Vendors are applied
         Assert.AreEqual(VendorCount, Vendor.Count(), 'Wrong number of Migrated Vendors read');
 
-        // [then] Then fields for Vendors 1 are correctly applied
+        // [THEN] The fields for Vendors 1 are correctly applied
         Vendor.SetRange("No.", '1160');
         Vendor.FindFirst();
 
@@ -376,7 +377,9 @@ codeunit 139664 "GP Data Migration Tests"
         Country := CompanyInformation."Country/Region Code";
 
         Assert.AreEqual('Risco, Inc.', Vendor.Name, 'Name of Migrated Vendor is wrong');
-        Assert.AreEqual('Risco, Inc.', Vendor."Name 2", 'Name 2 of Migrated Vendor is wrong');
+
+        // [THEN] The Vendor Name 2 will be blank because it is the same as the Vendor name
+        Assert.AreEqual('', Vendor."Name 2", 'Name 2 of Migrated Vendor is wrong');
         Assert.AreEqual('Roger', Vendor.Contact, 'Contact Name of Migrated Vendor is wrong');
         Assert.AreEqual('RISCO, INC.', Vendor."Search Name", 'Search Name of Migrated Vendor is wrong');
         Assert.AreEqual('2344 Brookings St', Vendor.Address, 'Address of Migrated Vendor is wrong');
@@ -485,6 +488,83 @@ codeunit 139664 "GP Data Migration Tests"
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestGPVendorImportWithName2()
+    var
+        Vendor: Record Vendor;
+        CompanyInformation: Record "Company Information";
+        Country: Code[10];
+    begin
+        // [SCENARIO] All Vendor are queried from GP
+        // [GIVEN] GP data
+        Initialize();
+        GPTestHelperFunctions.CreateConfigurationSettings();
+
+        // Enable Payables Module setting
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPCompanyAdditionalSettings.Validate("Migrate Payables Module", true);
+        GPCompanyAdditionalSettings.Modify();
+
+        // [WHEN] Data is imported
+        CreateVendorData();
+        GPTestHelperFunctions.InitializeMigration();
+
+        // [Then] The fields for the Vendor are correctly imported to temporary table
+        GPVendor.SetRange(VENDORID, '3070');
+        GPVendor.FindFirst();
+        Assert.AreEqual('L.M. Berry & co. -NYPS', GPVendor.VENDNAME, 'VENDNAME of Vendor is wrong');
+        Assert.AreEqual('L.M. Berry & co. -NYPS', GPVendor.SEARCHNAME, 'SEARCHNAME of Vendor is wrong');
+        Assert.AreEqual('L.M. Berry & co.', GPVendor.VNDCHKNM, 'VNDCHKNM of Vendor is wrong');
+        Assert.AreEqual('Box 90255', GPVendor.ADDRESS1, 'ADDRESS2 of Vendor is wrong');
+        Assert.AreEqual('', GPVendor.ADDRESS2, 'ADDRESS2 of Vendor is wrong');
+        Assert.AreEqual('Chicago', GPVendor.CITY, 'CITY of Vendor is wrong');
+        Assert.AreEqual('', GPVendor.VNDCNTCT, 'VNDCNTCT Phone of Vendor is wrong');
+        Assert.AreEqual('70143651130000', GPVendor.PHNUMBR1, 'PHNUMBR1 of Vendor is wrong');
+        Assert.AreEqual('2% EOM/Net 15th', GPVendor.PYMTRMID, 'PYMTRMID of Vendor is wrong');
+        Assert.AreEqual('MAIL', GPVendor.SHIPMTHD, 'SHIPMTHD of Vendor is wrong');
+        Assert.AreEqual('', GPVendor.COUNTRY, 'SLPRSNID of Vendor is wrong');
+        Assert.AreEqual('', GPVendor.PYMNTPRI, 'PYMNTPRI of Vendor is wrong');
+        Assert.AreEqual(-34.70, GPVendor.AMOUNT, 'AMOUNT of Vendor is wrong');
+        Assert.AreEqual('00000000000000', GPVendor.FAXNUMBR, 'FAXNUMBR of Vendor is wrong');
+        Assert.AreEqual('IL', GPVendor.STATE, 'STATE of Vendor is wrong');
+        Assert.AreEqual('505930011', GPVendor.ZIPCODE, 'ZIPCODE of Vendor is wrong');
+        Assert.AreEqual('', GPVendor.INET1, 'INET1 of Vendor is wrong');
+        Assert.AreEqual(' ', GPVendor.INET2, 'INET2 of Vendor is wrong');
+        Assert.AreEqual('P-N-TXB-%PTIP', GPVendor.TAXSCHID, 'TAXSCHID of Vendor is wrong');
+        Assert.AreEqual('J6', GPVendor.UPSZONE, 'UPSZONE of Vendor is wrong');
+        Assert.AreEqual('45-0029728', GPVendor.TXIDNMBR, 'TXIDNMBR of Vendor is wrong');
+
+        // [WHEN] data is migrated
+        Vendor.DeleteAll();
+        GPVendor.Reset();
+        MigrateVendors(GPVendor);
+
+        // [THEN] The fields for Vendors are correctly applied
+        Vendor.SetRange("No.", '3070');
+        Vendor.FindFirst();
+
+        CompanyInformation.Get();
+        Country := CompanyInformation."Country/Region Code";
+
+        Assert.AreEqual('L.M. Berry & co. -NYPS', Vendor.Name, 'Name of Migrated Vendor is wrong');
+
+        // [THEN] The Vendor Name 2 will be set because it is not the same as the Vendor name
+        Assert.AreEqual('L.M. Berry & co.', Vendor."Name 2", 'Name 2 of Migrated Vendor is wrong');
+        Assert.AreEqual('', Vendor.Contact, 'Contact Name of Migrated Vendor is wrong');
+        Assert.AreEqual('L.M. BERRY & CO. -NYPS', Vendor."Search Name", 'Search Name of Migrated Vendor is wrong');
+        Assert.AreEqual('Box 90255', Vendor.Address, 'Address of Migrated Vendor is wrong');
+        Assert.AreEqual('', Vendor."Address 2", 'Address2 of Migrated Vendor is wrong');
+        Assert.AreEqual('Chicago', Vendor.City, 'City of Migrated Vendor is wrong');
+        Assert.AreEqual('505930011', Vendor."Post Code", 'Post Code of Migrated Vendor is wrong');
+        Assert.AreEqual('IL', Vendor.County, 'County (State) of Migrated Vendor is wrong');
+        Assert.AreEqual('70143651130000', Vendor."Phone No.", 'Phone No. of Migrated Vendor is wrong');
+        Assert.AreEqual('', Vendor."Fax No.", 'Fax No. of Migrated Vendor is wrong');
+        Assert.AreEqual(Country, Vendor."Country/Region Code", 'Country/Region of Migrated Vendor is wrong');
+        Assert.AreEqual('MAIL', Vendor."Shipment Method Code", 'Shipment Method Code of Migrated Vendor is wrong');
+        Assert.AreEqual(true, Vendor."Tax Liable", 'Tax Liable of Migrated Vendor is wrong');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
     procedure TestPayablesMasterDataOnly()
     var
         Vendor: Record Vendor;
@@ -514,12 +594,14 @@ codeunit 139664 "GP Data Migration Tests"
         // [WHEN] adding Vendors, update the expected count here
         VendorCount := 54;
 
+        Clear(GPVendor);
+        Clear(Vendor);
+
         // [THEN] Then the correct number of Vendors are imported
         Assert.AreEqual(VendorCount, GPVendor.Count(), 'Wrong number of Vendor read');
 
         // [WHEN] data is migrated
         Vendor.DeleteAll();
-        GPVendor.Reset();
         MigrateVendors(GPVendor);
 
         // [THEN] Then the correct number of Vendors are applied
@@ -555,13 +637,15 @@ codeunit 139664 "GP Data Migration Tests"
         // When adding Vendors, update the expected count here
         VendorCount := 54;
 
+        Clear(GPVendor);
+        Clear(Vendor);
+
         // [then] Then the correct number of GPVendors are imported
         Assert.AreEqual(VendorCount, GPVendor.Count(), 'Wrong number of GPVendors found.');
         Assert.AreEqual(0, HelperFunctions.GetNumberOfVendors(), 'Wrong number of Vendors calculated.');
 
         // [WHEN] data is migrated
         Vendor.DeleteAll();
-        GPVendor.Reset();
         MigrateVendors(GPVendor);
 
         Assert.RecordCount(Vendor, 0);
@@ -1856,7 +1940,7 @@ codeunit 139664 "GP Data Migration Tests"
         GPVendor.VENDORID := '3070';
         GPVendor.VENDNAME := 'L.M. Berry & co. -NYPS';
         GPVendor.SEARCHNAME := 'L.M. Berry & co. -NYPS';
-        GPVendor.VNDCHKNM := 'L.M. Berry & co. -NYPS';
+        GPVendor.VNDCHKNM := 'L.M. Berry & co.';
         GPVendor.ADDRESS1 := 'Box 90255';
         GPVendor.ADDRESS2 := '';
         GPVendor.CITY := 'Chicago';


### PR DESCRIPTION
This change updates the Vendor migration logic to not migrate Name 2 (Vendor check name) if it's the same as vendor name.
This includes some code cleanup too.