### PR TITLE
Skip PO Line over-receipt validation when the line quantity value is being set

### DIFF
--- a/Apps/W1/HybridGP/app/src/codeunits/HybridGPManagement.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/HybridGPManagement.codeunit.al
@@ -49,6 +49,18 @@ codeunit 4016 "Hybrid GP Management"
         CloseWizard := true;
     end;
 
+    [EventSubscriber(ObjectType::Table, Database::"Purchase Line", 'OnValidateQuantityOnBeforeCheckWithQuantityReceived', '', false, false)]
+    local procedure OnValidateQuantityOnBeforeCheckWithQuantityReceived(var PurchaseLine: Record "Purchase Line"; var IsHandled: Boolean)
+    begin
+        IsHandled := true;
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Purchase Line", 'OnValidateQtyToReceiveOnAfterInitQty', '', false, false)]
+    local procedure OnValidateQtyToReceiveOnAfterInitQty(var PurchaseLine: Record "Purchase Line"; var xPurchaseLine: Record "Purchase Line"; CallingFieldNo: Integer; var IsHandled: Boolean)
+    begin
+        IsHandled := true;
+    end;
+
     local procedure UpdateStatusOnHybridReplicationCompleted(RunId: Text[50]; NotificationText: Text)
     var
         HybridReplicationDetail: Record "Hybrid Replication Detail";


### PR DESCRIPTION
Prior to the [PO Line count issue fix](https://github.com/microsoft/ALAppExtensions/pull/22215), BC's PO Line over-receipt validation was skipped because the "Quantity Received" field was set after the Quantity, meaning the "Quantity Received" value was always zero when the over-receipt validation would have occured. Since that fix, the BC over-receipt validation is failing migrations when the Quantity Received is greater than the Quantity, even though over-receipt handling is performed a little later in the migration code.

This change allows for BC to skip the over-receipt validation when the PO Line Quantity field is being set. Proper over-receipt handling is being performed during the migration and this validation isn't wanted at the time of setting the Quantity value.