### PR TITLE
Prevent migrating a previously migrated Company on subsequent migration runs

### DIFF
--- a/Apps/W1/HybridBaseDeployment/app/src/codeunits/cod4001.HybridCloudManagement.al
+++ b/Apps/W1/HybridBaseDeployment/app/src/codeunits/cod4001.HybridCloudManagement.al
@@ -1750,6 +1750,11 @@ codeunit 4001 "Hybrid Cloud Management"
         HybridCompanyStatusExist: Boolean;
     begin
         HybridCompanyStatusExist := HybridCompanyStatus.Get(HybridCompanyName);
+
+        if HybridCompanyStatusExist then
+            if (HybridCompanyStatus."Upgrade Status" = HybridCompanyStatus."Upgrade Status"::Completed) then
+                exit;
+
         HybridCompanyStatus.Replicated := true;
         HybridCompanyStatus."Upgrade Status" := HybridCompanyStatus."Upgrade Status"::Pending;
         if HybridCompanyStatusExist then


### PR DESCRIPTION
This change prevents migrating a previously migrated Company on subsequent migration runs.
Example: Migrate Company A, then migrate Company B later without Company A being attempted again.

Note: This is in the Hybrid Base app and I have been working with Nikola on the best approach.