### PR TITLE
Retain migrated Company settings, but hidden on config page

### DIFF
--- a/Apps/W1/HybridGP/app/src/pages/GPCompanyAddSettingsList.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPCompanyAddSettingsList.Page.al
@@ -3,7 +3,7 @@ page 4051 "GP Company Add. Settings List"
     Caption = 'GP Company Additional Settings List';
     PageType = ListPart;
     SourceTable = "GP Company Additional Settings";
-    SourceTableView = sorting(Name) where("Name" = filter(<> ''));
+    SourceTableView = sorting(Name) where("Name" = filter(<> ''), "Migration Completed" = const(false));
     DeleteAllowed = false;
     InsertAllowed = false;
     ModifyAllowed = true;

--- a/Apps/W1/HybridGP/app/src/pages/GPMigrationConfiguration.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPMigrationConfiguration.Page.al
@@ -603,6 +603,7 @@ page 4050 "GP Migration Configuration"
     local procedure PrepSettingsForFieldUpdate(): Boolean
     begin
         GPCompanyAdditionalSettings.SetFilter("Name", '<>%1', '');
+        GPCompanyAdditionalSettings.SetRange("Migration Completed", false);
         exit(GPCompanyAdditionalSettings.FindSet());
     end;
 
@@ -610,6 +611,7 @@ page 4050 "GP Migration Configuration"
     var
         GPCompanyAdditionalSettingsInit: Record "GP Company Additional Settings";
     begin
+        GPCompanyAdditionalSettingsInit.SetRange("Migration Completed", false);
         GPCompanyAdditionalSettingsInit.DeleteAll();
 
         Rec.Init();
@@ -678,6 +680,7 @@ page 4050 "GP Migration Configuration"
         GPCompanyAdditionalSettingsCompanies: Record "GP Company Additional Settings";
     begin
         GPCompanyAdditionalSettingsCompanies.SetFilter("Name", '<>%1', '');
+        GPCompanyAdditionalSettingsCompanies.SetRange("Migration Completed", false);
         if GPCompanyAdditionalSettingsCompanies.FindSet() then
             repeat
                 if (GPCompanyAdditionalSettingsCompanies."Global Dimension 1" = '') then
@@ -696,6 +699,7 @@ page 4050 "GP Migration Configuration"
         GPCompanyAdditionalSettingsCompanies: Record "GP Company Additional Settings";
     begin
         GPCompanyAdditionalSettingsCompanies.SetFilter("Name", '<>%1', '');
+        GPCompanyAdditionalSettingsCompanies.SetRange("Migration Completed", false);
         if GPCompanyAdditionalSettingsCompanies.FindSet() then
             repeat
                 if (DimensionLabel = '') or CompanyHasSegment(GPCompanyAdditionalSettingsCompanies.Name, DimensionLabel) then begin

--- a/Apps/W1/HybridGP/app/src/pages/HybridCloudWizardExtension.PageExt.al
+++ b/Apps/W1/HybridGP/app/src/pages/HybridCloudWizardExtension.PageExt.al
@@ -73,28 +73,10 @@ pageextension 4014 "Hybrid Cloud Wizard Extension" extends "Hybrid Cloud Setup W
         {
             trigger OnAfterAction()
             begin
-                if Rec."Product ID" = 'DynamicsGP' then begin
-                    CleanupSettingsForCompaniesPreviouslyMigrated();
+                if Rec."Product ID" = 'DynamicsGP' then
                     Page.Run(Page::"GP Migration Configuration");
-                end;
             end;
 
         }
     }
-
-    local procedure CleanupSettingsForCompaniesPreviouslyMigrated()
-    var
-        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
-        HybridCompany: Record "Hybrid Company";
-    begin
-        GPCompanyAdditionalSettings.SetFilter("Name", '<>%1', '');
-        if GPCompanyAdditionalSettings.FindSet() then
-            repeat
-                HybridCompany.SetRange(Name, GPCompanyAdditionalSettings.Name);
-                HybridCompany.SetRange(Replicate, false);
-
-                if not HybridCompany.IsEmpty() then
-                    GPCompanyAdditionalSettings.Delete();
-            until GPCompanyAdditionalSettings.Next() = 0;
-    end;
 }

--- a/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
+++ b/Apps/W1/HybridGP/app/src/tables/GPCompanyAdditionalSettings.table.al
@@ -320,6 +320,11 @@ table 40105 "GP Company Additional Settings"
             DataClassification = SystemMetadata;
             InitValue = true;
         }
+        field(35; "Migration Completed"; Boolean)
+        {
+            FieldClass = FlowField;
+            CalcFormula = exist("Hybrid Company Status" where("Name" = field(Name), "Upgrade Status" = const("Completed")));
+        }
     }
 
     keys


### PR DESCRIPTION
The migrated Company configuration settings need to be retained for troubleshooting purposes after a migration.

- The Company configuration settings record will no longer be deleted (GP Company Additional Settings).
- It will not be shown in the Company settings list on the configuration page.
- Global settings changes will not update these records.