### PR TITLE
Changes to fix PO posting issues

### DIFF
--- a/Apps/W1/HybridGP/app/src/codeunits/HybridGPManagement.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/HybridGPManagement.codeunit.al
@@ -38,6 +38,18 @@ codeunit 4016 "Hybrid GP Management"
         CloseWizard := true;
     end;
 
+    [EventSubscriber(ObjectType::Table, Database::"Purchase Line", 'OnValidateQuantityOnBeforeCheckWithQuantityReceived', '', false, false)]
+    local procedure OnValidateQuantityOnBeforeCheckWithQuantityReceived(var PurchaseLine: Record "Purchase Line"; var IsHandled: Boolean)
+    begin
+        IsHandled := true;
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Purchase Line", 'OnValidateQtyToReceiveOnAfterInitQty', '', false, false)]
+    local procedure OnValidateQtyToReceiveOnAfterInitQty(var PurchaseLine: Record "Purchase Line"; var xPurchaseLine: Record "Purchase Line"; CallingFieldNo: Integer; var IsHandled: Boolean)
+    begin
+        IsHandled := true;
+    end;
+
     local procedure UpdateStatusOnHybridReplicationCompleted(RunId: Text[50]; NotificationText: Text)
     var
         HybridReplicationDetail: Record "Hybrid Replication Detail";


### PR DESCRIPTION
When migrating Open POs, if a line has already been received or partially received, generate the Purchase Receipt, Receipt Line, and GL entries that go with it. Additionally, create a negative adjustment to prevent quantity issues.