### PR TITLE
Don't perform the staging combine step if the setting is not configured to migrate

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/GPTables/GPPopulateCombinedTables.Codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/GPTables/GPPopulateCombinedTables.Codeunit.al
@@ -1,16 +1,37 @@
 codeunit 40125 "GP Populate Combined Tables"
 {
     internal procedure PopulateAllMappedTables()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
     begin
         PopulateGPAccount();
         PouplateGPFiscalPeriods();
-        PopulateGPGLTransactions();
-        PopulateGPCustomer();
-        PopulateGPCustomerTransactions();
-        PopulateGPVendors();
-        PopulateGPVendorTransactions();
-        PopulateGPItem();
-        PopulateGPItemTransactions();
+
+        if not GPCompanyAdditionalSettings.GetMigrateOnlyGLMaster() then
+            PopulateGPGLTransactions();
+
+        if GPCompanyAdditionalSettings.GetReceivablesModuleEnabled() then begin
+            PopulateGPCustomer();
+
+            if not GPCompanyAdditionalSettings.GetMigrateOnlyReceivablesMaster() then
+                PopulateGPCustomerTransactions();
+        end;
+
+        if GPCompanyAdditionalSettings.GetPayablesModuleEnabled() then begin
+            PopulateGPVendors();
+
+            if not GPCompanyAdditionalSettings.GetMigrateOnlyPayablesMaster() then
+                PopulateGPVendorTransactions();
+        end;
+
+
+        if GPCompanyAdditionalSettings.GetInventoryModuleEnabled() then begin
+            PopulateGPItem();
+
+            if not GPCompanyAdditionalSettings.GetMigrateOnlyInventoryMaster() then
+                PopulateGPItemTransactions();
+        end;
+
         PopulateCodes();
         PopulateGPSegments();
         PopulateGPPostingAccountsTable();

--- a/Apps/W1/HybridGP/test/src/GPSettingsTests.codeunit.al
+++ b/Apps/W1/HybridGP/test/src/GPSettingsTests.codeunit.al
@@ -488,6 +488,449 @@ codeunit 139681 "GP Settings Tests"
         Assert.IsTrue(GPConfiguration.IsAllPostMigrationDataCreated(), 'Should return true because all of the entries should be created.');
     end;
 
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicNotMasterGLOnly()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPGLTransactions: Record "GP GLTransactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Not migrating only GL master
+        GPCompanyAdditionalSettings.Validate("Migrate Only GL Master", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] Records should be created in the GP GLTransactions combined staging table
+        Assert.AreEqual(1, GPGLTransactions.Count(), 'Transaction records should have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicMasterGLOnly()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPGLTransactions: Record "GP GLTransactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Migrating only GL master
+        GPCompanyAdditionalSettings.Validate("Migrate Only GL Master", true);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] No records should be created in the GP GLTransactions combined staging table
+        Assert.AreEqual(0, GPGLTransactions.Count(), 'Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicReceivablesModuleEnabledMasterDataOnlyDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPCustomer: Record "GP Customer";
+        GPCustomerTransactions: Record "GP Customer Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Receivables module enabled, and not migrating only Receivables master data
+        GPCompanyAdditionalSettings.Validate("Migrate Receivables Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Rec. Master", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] Both GP Customer and GP Customer Transaction records will be created
+        Assert.AreEqual(1, GPCustomer.Count(), 'Customer records should have been created.');
+        Assert.AreEqual(1, GPCustomerTransactions.Count(), 'Customer Transaction records should have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicReceivablesModuleEnabledMasterDataOnlyEnabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPCustomer: Record "GP Customer";
+        GPCustomerTransactions: Record "GP Customer Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Migrating only Receivables master data
+        GPCompanyAdditionalSettings.Validate("Migrate Receivables Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Rec. Master", true);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] GP Customer will be created, but not GP Customer Transactions
+        Assert.AreEqual(1, GPCustomer.Count(), 'Customer records should have been created.');
+        Assert.AreEqual(0, GPCustomerTransactions.Count(), 'Customer Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicReceivablesModuleDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPCustomer: Record "GP Customer";
+        GPCustomerTransactions: Record "GP Customer Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Receivables module disabled
+        GPCompanyAdditionalSettings.Validate("Migrate Receivables Module", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] No GP Customer or GP Customer Transaction records will be created
+        Assert.AreEqual(0, GPCustomer.Count(), 'Customer records should not have been created.');
+        Assert.AreEqual(0, GPCustomerTransactions.Count(), 'Customer Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicPayablesModuleEnabledMasterDataOnlyDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPVendor: Record "GP Vendor";
+        GPVendorTransactions: Record "GP Vendor Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Payables module enabled, and not migrating only Payables master data
+        GPCompanyAdditionalSettings.Validate("Migrate Payables Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Payables Master", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] Both GP Vendor and GP Vendor Transaction records will be created
+        Assert.AreEqual(1, GPVendor.Count(), 'Vendor records should have been created.');
+        Assert.AreEqual(1, GPVendorTransactions.Count(), 'Vendor Transaction records should have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicPayablesModuleEnabledMasterDataOnlyEnabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPVendor: Record "GP Vendor";
+        GPVendorTransactions: Record "GP Vendor Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Migrating only Payables master data
+        GPCompanyAdditionalSettings.Validate("Migrate Payables Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Payables Master", true);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] GP Vendor will be created, but not GP Vendor Transactions
+        Assert.AreEqual(1, GPVendor.Count(), 'Vendor records should have been created.');
+        Assert.AreEqual(0, GPVendorTransactions.Count(), 'Vendor Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicPayablesModuleDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPVendor: Record "GP Vendor";
+        GPVendorTransactions: Record "GP Vendor Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Payables module disabled
+        GPCompanyAdditionalSettings.Validate("Migrate Payables Module", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] No GP Vendor or GP Vendor Transaction records will be created
+        Assert.AreEqual(0, GPVendor.Count(), 'Vendor records should not have been created.');
+        Assert.AreEqual(0, GPVendorTransactions.Count(), 'Vendor Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicInventoryModuleEnabledMasterDataOnlyDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPItem: Record "GP Item";
+        GPItemTransactions: Record "GP Item Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Inventory module enabled, and not migrating only Inventory master data
+        GPCompanyAdditionalSettings.Validate("Migrate Inventory Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Inventory Master", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] Both GP Item and GP Item Transaction records will be created
+        Assert.AreEqual(1, GPItem.Count(), 'Item records should have been created.');
+        Assert.AreEqual(1, GPItemTransactions.Count(), 'Item Transaction records should have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicInventoryModuleEnabledMasterDataOnlyEnabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPItem: Record "GP Item";
+        GPItemTransactions: Record "GP Item Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Migrating only Inventory master data
+        GPCompanyAdditionalSettings.Validate("Migrate Inventory Module", true);
+        GPCompanyAdditionalSettings.Validate("Migrate Only Inventory Master", true);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] GP Items will be created, but not GP Item Transactions
+        Assert.AreEqual(1, GPItem.Count(), 'Item records should have been created.');
+        Assert.AreEqual(0, GPItemTransactions.Count(), 'Item Transaction records should not have been created.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestPopulateCombineStagingLogicInventoryModuleDisabled()
+    var
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPConfiguration: Record "GP Configuration";
+        GPItem: Record "GP Item";
+        GPItemTransactions: Record "GP Item Transactions";
+        GPPopulateCombinedTables: Codeunit "GP Populate Combined Tables";
+    begin
+        // [SCENARIO] Settings are created and data has been replicated
+        GPTestHelperFunctions.CreateConfigurationSettings();
+        GPCompanyAdditionalSettings.GetSingleInstance();
+        GPConfiguration.GetSingleInstance();
+        CreateReplicatedData();
+
+        // [WHEN] Inventory module disabled
+        GPCompanyAdditionalSettings.Validate("Migrate Inventory Module", false);
+        GPCompanyAdditionalSettings.Modify();
+        GPPopulateCombinedTables.PopulateAllMappedTables();
+
+        // [THEN] No GP Item or GP Item Transaction records will be created
+        Assert.AreEqual(0, GPItem.Count(), 'Item records should not have been created.');
+        Assert.AreEqual(0, GPItemTransactions.Count(), 'Item Transaction records should not have been created.');
+    end;
+
+    local procedure CreateReplicatedData()
+    var
+        GPGL00100: Record "GP GL00100";
+        GPGL40200: Record "GP GL40200";
+        GPSY00300: Record "GP SY00300";
+        GPGL10110: Record "GP GL10110";
+        GPGL10111: Record "GP GL10111";
+        GPSY40100: Record "GP SY40100";
+        GPSY40101: Record "GP SY40101";
+        GPRM00101: Record "GP RM00101";
+        GPRM20101: Record "GP RM20101";
+        GPPM00200: Record "GP PM00200";
+        GPPM20000: Record "GP PM20000";
+        GPIV00101: Record "GP IV00101";
+        GPIV10200: Record "GP IV10200";
+    begin
+        if not GPSY00300.IsEmpty() then
+            GPSY00300.DeleteAll();
+
+        if not GPGL10110.IsEmpty() then
+            GPGL10110.DeleteAll();
+
+        if not GPGL10111.IsEmpty() then
+            GPGL10111.DeleteAll();
+
+        if not GPGL00100.IsEmpty() then
+            GPGL00100.DeleteAll();
+
+        if not GPSY40100.IsEmpty() then
+            GPSY40100.DeleteAll();
+
+        if not GPSY40101.IsEmpty() then
+            GPSY40101.DeleteAll();
+
+        if not GPGL40200.IsEmpty() then
+            GPGL40200.DeleteAll();
+
+        if not GPRM00101.IsEmpty() then
+            GPRM00101.DeleteAll();
+
+        if not GPRM20101.IsEmpty() then
+            GPRM20101.DeleteAll();
+
+        if not GPPM00200.IsEmpty() then
+            GPPM00200.DeleteAll();
+
+        if not GPPM20000.IsEmpty() then
+            GPPM20000.DeleteAll();
+
+        if not GPIV00101.IsEmpty() then
+            GPIV00101.DeleteAll();
+
+        if not GPIV10200.IsEmpty() then
+            GPIV10200.DeleteAll();
+
+        // GL
+        GPSY00300.MNSEGIND := true;
+        GPSY00300.SGMTNUMB := 1;
+        GPSY00300.Insert();
+
+        GPGL00100.ACTINDX := 1;
+        GPGL00100.ACTNUMBR_1 := '1200';
+        GPGL00100.ACCTTYPE := 1;
+        GPGL00100.ACTDESCR := 'Test account';
+        GPGL00100.Insert();
+
+        GPGL10110.PERDBLNC := 1;
+        GPGL10110.GL00100ACCTYPE1Exist := true;
+        GPGL10110.YEAR1 := 2023;
+        GPGL10110.PERIODID := 1;
+        GPGL10110.ACTNUMBR_1 := GPGL00100.ACTNUMBR_1;
+        GPGL10110.ACTINDX := 1;
+        GPGL10110.CRDTAMNT := 100;
+        GPGL10110.Insert();
+
+        GPSY40101.YEAR1 := 2023;
+        GPSY40101.Insert();
+
+        GPSY40100.PERIODID := 1;
+        GPSY40100.SERIES := 0;
+        GPSY40100.YEAR1 := 2023;
+        GPSY40100.PERIODDT := CurrentDateTime();
+        GPSY40100.PERDENDT := CurrentDateTime();
+        GPSY40100.Insert();
+
+        // Receivables
+        GPRM00101.CUSTNMBR := 'CUST1';
+        GPRM00101.CUSTNAME := 'Customer name';
+        GPRM00101.CITY := 'Fargo';
+        GPRM00101.STATE := 'ND';
+        GPRM00101.ZIP := '58103-3342';
+        GPRM00101.TAXSCHID := 'S-T-NO-%AD%S';
+        GPRM00101.UPSZONE := 'P3';
+        GPRM00101.Insert();
+
+        GPRM20101.RMDTYPAL := 1;
+        GPRM20101.CURTRXAM := 100;
+        GPRM20101.VOIDSTTS := 0;
+        GPRM20101.CUSTNMBR := GPRM00101.CUSTNMBR;
+        GPRM20101.DOCNUMBR := 'DOC123';
+        GPRM20101.DOCDATE := Today();
+        GPRM20101.SLPRSNID := 'Somebody';
+        GPRM20101.PYMTRMID := '2.5% EOM/EOM';
+        GPRM20101.Insert();
+
+        // Payables
+        GPPM00200.VENDORID := 'V3130';
+        GPPM00200.VENDSTTS := 1;
+        GPPM00200.VENDNAME := 'Lmd Telecom, Inc.';
+        GPPM00200.VNDCHKNM := 'Lmd Telecom, Inc.';
+        GPPM00200.ADDRESS1 := 'P.O. Box10158';
+        GPPM00200.CITY := 'Fort Worth';
+        GPPM00200.PYMTRMID := '3% 15th/Net 30';
+        GPPM00200.SHIPMTHD := 'UPS BLUE';
+        GPPM00200.ZIPCODE := '76114';
+        GPPM00200.STATE := 'TX';
+        GPPM00200.TAXSCHID := 'P-T-TXB-%PT%P*4';
+        GPPM00200.UPSZONE := 'F4';
+        GPPM00200.TXIDNMBR := '45-0029728';
+        GPPM00200.Insert();
+
+        GPPM20000.VENDORID := GPPM00200.VENDORID;
+        GPPM20000.DOCNUMBR := 'DOC01';
+        GPPM20000.DOCTYPE := 1;
+        GPPM20000.DOCDATE := Today();
+        GPPM20000.DUEDATE := Today();
+        GPPM20000.CURTRXAM := 100;
+        GPPM20000.PYMTRMID := GPPM00200.PYMTRMID;
+        GPPM20000.Insert();
+
+        // Inventory
+        GPIV00101.ITEMTYPE := 1;
+        GPIV00101.ITEMNMBR := 'Item1';
+        GPIV00101.ITEMDESC := 'Item description';
+        GPIV00101.VCTNMTHD := 1;
+        GPIV00101.CURRCOST := 1;
+        GPIV00101.STNDCOST := 1;
+        GPIV00101.SELNGUOM := 'EACH';
+        GPIV00101.PRCHSUOM := 'EACH';
+        GPIV00101.ITMTRKOP := 2;
+        GPIV00101.ITEMSHWT := 500;
+        GPIV00101.ITMTRKOP := 1;
+        GPIV00101.Insert();
+
+        GPIV10200.ITEMNMBR := GPIV00101.ITEMNMBR;
+        GPIV10200.TRXLOCTN := 'WAREHOUSE';
+        GPIV10200.UNITCOST := 1;
+        GPIV10200.RCTSEQNM := 1;
+        GPIV10200.RCPTNMBR := 'R101';
+        GPIV10200.DATERECD := Today();
+        GPIV10200.RCPTSOLD := false;
+        GPIV10200.QTYRECVD := 1;
+        GPIV10200.Insert();
+    end;
+
     local procedure CreateSettingsTableEntries()
     var
         GPCompanyMigrationSettings: Record "GP Company Migration Settings";


### PR DESCRIPTION
An initial step for a migration is the combining of multiple staging tables into a single table for later processing (replacement of the SQL queries). This area of the code can be optimized to only perform this operation when configured to and skip otherwise. If configured to migrate less data, this would reduce both the time a migration would take, and the amount of space used by the staging tables.

GP Customers and GP Customer Transactions should not be populated if the Receivables module is disabled.
GP Customer Transactions should not be populated if migrating only Receivables master data.
GP Vendor and GP Vendor Transactions should not be populated if the Payables module is disabled.
GP Vendor Transactions should not be populated if migrating only Payables master data.
GP Item and GP Item Transactions should not be populated if the Inventory module is disabled.
GP Item Transactions should not be populated if migrating only Inventory master data.
GP GLTransactions should not be populated if only migrating master GL data.

[Product Backlog Item 7719](https://dev.azure.com/EPS-Product/EPS-Product/_workitems/edit/7719): Don't perform the staging combine step if the module is not configured to migrate