### PR TITLE
Posting Group account number should default to Posting Setup when the Posting Group account number is empty

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
@@ -513,10 +513,10 @@ codeunit 4018 "GP Customer Migrator"
         GPRM00201: Record "GP RM00201";
         HelperFunctions: Codeunit "Helper Functions";
         CustomerClassId: Text[20];
-        DefaultReceivablesAccount: Code[20];
+        DefaultReceivablesAccountNo: Code[20];
     begin
-        DefaultReceivablesAccount := HelperFunctions.GetPostingAccountNumber('ReceivablesAccount');
-        ReceivablesAccountNo := DefaultReceivablesAccount;
+        DefaultReceivablesAccountNo := HelperFunctions.GetPostingAccountNumber('ReceivablesAccount');
+        ReceivablesAccountNo := DefaultReceivablesAccountNo;
 
         if not GPCompanyAdditionalSettings.GetMigrateCustomerClasses() then
             exit;
@@ -535,6 +535,9 @@ codeunit 4018 "GP Customer Migrator"
             exit;
 
         ReceivablesAccountNo := HelperFunctions.GetGPAccountNumberByIndex(GPRM00201.RMARACC);
+
+        if ReceivablesAccountNo = '' then
+            ReceivablesAccountNo := DefaultReceivablesAccountNo;
     end;
 
     procedure MigrateCustomerClasses()

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -668,10 +668,10 @@ codeunit 4022 "GP Vendor Migrator"
         GPPM00100: Record "GP PM00100";
         HelperFunctions: Codeunit "Helper Functions";
         VendorClassId: Text[20];
-        DefaultPayablesAccount: Code[20];
+        DefaultPayablesAccountNo: Code[20];
     begin
-        DefaultPayablesAccount := HelperFunctions.GetPostingAccountNumber('PayablesAccount');
-        PayablesAccountNo := DefaultPayablesAccount;
+        DefaultPayablesAccountNo := HelperFunctions.GetPostingAccountNumber('PayablesAccount');
+        PayablesAccountNo := DefaultPayablesAccountNo;
 
         if not GPCompanyAdditionalSettings.GetMigrateVendorClasses() then
             exit;
@@ -690,6 +690,9 @@ codeunit 4022 "GP Vendor Migrator"
             exit;
 
         PayablesAccountNo := HelperFunctions.GetGPAccountNumberByIndex(GPPM00100.PMAPINDX);
+
+        if PayablesAccountNo = '' then
+            PayablesAccountNo := DefaultPayablesAccountNo;
     end;
 
     procedure MigrateVendorClasses()

--- a/Apps/W1/HybridGP/test/src/GPDataMigrationTests.codeunit.al
+++ b/Apps/W1/HybridGP/test/src/GPDataMigrationTests.codeunit.al
@@ -159,19 +159,19 @@ codeunit 139664 "GP Data Migration Tests"
         // [WHEN] Customer classes are migrated
         Assert.AreEqual('100', HelperFunctions.GetPostingAccountNumber('ReceivablesAccount'), 'Default Receivables account is incorrect.');
 
-        // [THEN] The class Receivables account will be used for transactions when an account is configured for the class
+        // [THEN] The class Receivables account will be used for transactions when an account is configured for the class with an account number
         Clear(GenJournalLine);
         GenJournalLine.SetRange("Account Type", "Gen. Journal Account Type"::Customer);
         GenJournalLine.SetRange("Account No.", '!WOW!');
         Assert.IsTrue(GenJournalLine.FindFirst(), 'Could not locate Gen. Journal Line.');
         Assert.AreEqual('TEST987', GenJournalLine."Bal. Account No.", 'Incorrect Bal. Account No. on Gen. Journal Line.');
 
-        // [THEN] No account will be set for the Bal. Account No. where class has no account configured
+        // [THEN] The default account will be set for the Bal. Account No. where class has no account configured
         Clear(GenJournalLine);
         GenJournalLine.SetRange("Account Type", "Gen. Journal Account Type"::Customer);
         GenJournalLine.SetRange("Account No.", '#1');
         Assert.IsTrue(GenJournalLine.FindFirst(), 'Could not locate Gen. Journal Line.');
-        Assert.AreEqual('', GenJournalLine."Bal. Account No.", 'Incorrect Bal. Account No. on Gen. Journal Line.');
+        Assert.AreEqual(HelperFunctions.GetPostingAccountNumber('ReceivablesAccount'), GenJournalLine."Bal. Account No.", 'Incorrect Bal. Account No. on Gen. Journal Line.');
     end;
 
     [Test]
@@ -523,7 +523,7 @@ codeunit 139664 "GP Data Migration Tests"
         GenJournalLine.SetRange("Account Type", "Gen. Journal Account Type"::Vendor);
         GenJournalLine.SetRange("Account No.", 'V3130');
         Assert.IsTrue(GenJournalLine.FindFirst(), 'Could not locate Gen. Journal Line.');
-        Assert.AreEqual('1', GenJournalLine."Bal. Account No.", 'Incorrect Bal. Account No. on Gen. Journal Line.');
+        Assert.AreEqual(HelperFunctions.GetPostingAccountNumber('PayablesAccount'), GenJournalLine."Bal. Account No.", 'Incorrect Bal. Account No. on Gen. Journal Line.');
     end;
 
     [Test]


### PR DESCRIPTION
[Product Backlog Item 9361](https://dev.azure.com/EPS-Product/EPS-Product/_workitems/edit/9361): Posting Group account number should default to Posting Setup when the Posting Group account number is empty