### PR TITLE
Work for Feature 419

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Items/GPIV00101.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Items/GPIV00101.Table.al
@@ -29,6 +29,10 @@ table 40116 "GP IV00101"
         {
             DataClassification = CustomerContent;
         }
+        field(11; DECPLCUR; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
         field(14; IVIVINDX; Integer)
         {
             DataClassification = CustomerContent;
@@ -83,5 +87,23 @@ table 40116 "GP IV00101"
     procedure IsDiscontinued(): Boolean
     begin
         exit(Rec.ITEMTYPE = DiscontinuedItemTypeId());
+    end;
+
+    procedure GetRoundingPrecision(GPDecimalPlaceId: Integer): Decimal
+    begin
+        Case GPDecimalPlaceId of
+            6:
+                exit(0.00001);
+            5:
+                exit(0.0001);
+            4:
+                exit(0.001);
+            3:
+                exit(0.01);
+            2:
+                exit(0.1);
+            else
+                exit(0);
+        End;
     end;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Items/GPItemAggregate.Query.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Items/GPItemAggregate.Query.al
@@ -1,0 +1,15 @@
+query 40101 "GP Item Aggregate"
+{
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(GPIV00101; "GP IV00101")
+        {
+            column(DECPLCUR; DECPLCUR)
+            {
+                Method = Max;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Support GP Rounding Precision For Item Unit Cost

[Product Backlog Item 419](https://dev.azure.com/EPS-Product/EPS-Product/_workitems/edit/419): Support GP Rounding Precision For Item Unit Cost

Update the General Ledger Setup record "Unit-Amount Rounding Precision" value to match the greatest number of decimal places supported by a GP Item.