### PR TITLE
PR for 9410, 9412, and History snapshot performance enhancements

### DIFF
--- a/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
@@ -115,5 +115,6 @@ permissionset 4031 "HybridGP - Edit"
                     tabledata "GP Hist. Source Error" = IMD,
                     tabledata "GP POP10100" = IMD,
                     tabledata "GP POP10110" = IMD,
-                    tabledata "GP PM00204" = IMD;
+                    tabledata "GP PM00204" = IMD,
+                    tabledata "GP Migration Email Address" = IMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
@@ -144,5 +144,8 @@ permissionset 4029 "HybridGP - Objects"
                     page "Hist. Migration Status Factbox" = X,
                     table "GP POP10100" = X,
                     table "GP POP10110" = X,
-                    table "GP PM00204" = X;
+                    table "GP PM00204" = X,
+                    table "GP Migration Email Address" = X,
+                    codeunit "GP Migration Notifier" = X,
+                    page "GP Migration Email Addresses" = X;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
@@ -115,5 +115,6 @@ permissionset 4032 "HybridGP - Read"
                     tabledata "GP Hist. Source Error" = R,
                     tabledata "GP POP10100" = R,
                     tabledata "GP POP10110" = R,
-                    tabledata "GP PM00204" = R;
+                    tabledata "GP PM00204" = R,
+                    tabledata "GP Migration Email Address" = R;
 }

--- a/Apps/W1/HybridGP/app/Permissions/INTELLIGENTCLOUDHGP.PermissionSetExt.al
+++ b/Apps/W1/HybridGP/app/Permissions/INTELLIGENTCLOUDHGP.PermissionSetExt.al
@@ -104,5 +104,6 @@ permissionsetextension 4028 "INTELLIGENT CLOUD - HGP" extends "INTELLIGENT CLOUD
                   tabledata "GP Hist. Source Error" = RIMD,
                   tabledata "GP POP10100" = RIMD,
                   tabledata "GP POP10110" = RIMD,
-                  tabledata "GP PM00204" = RIMD;
+                  tabledata "GP PM00204" = RIMD,
+                  tabledata "GP Migration Email Address" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
@@ -104,5 +104,6 @@ permissionsetextension 4025 "D365 BASIC - HGP" extends "D365 BASIC"
                   tabledata "GP Hist. Source Error" = RIMD,
                   tabledata "GP POP10100" = RIMD,
                   tabledata "GP POP10110" = RIMD,
-                  tabledata "GP PM00204" = RIMD;
+                  tabledata "GP PM00204" = RIMD,
+                  tabledata "GP Migration Email Address" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
@@ -104,5 +104,6 @@ permissionsetextension 4026 "D365 BASIC ISV - HGP" extends "D365 BASIC ISV"
                   tabledata "GP Hist. Source Error" = RIMD,
                   tabledata "GP POP10100" = RIMD,
                   tabledata "GP POP10110" = RIMD,
-                  tabledata "GP PM00204" = RIMD;
+                  tabledata "GP PM00204" = RIMD,
+                  tabledata "GP Migration Email Address" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
@@ -104,5 +104,6 @@ permissionsetextension 4027 "D365 TEAM MEMBER - HGP" extends "D365 TEAM MEMBER"
                   tabledata "GP Hist. Source Error" = RIMD,
                   tabledata "GP POP10100" = RIMD,
                   tabledata "GP POP10110" = RIMD,
-                  tabledata "GP PM00204" = RIMD;
+                  tabledata "GP PM00204" = RIMD,
+                  tabledata "GP Migration Email Address" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/app.json
+++ b/Apps/W1/HybridGP/app/app.json
@@ -29,7 +29,13 @@
                              "name":  "Sales and Inventory Forecast",
                              "publisher":  "Microsoft",
                              "version":  "22.3.0.0"
-                         }
+                        },
+                        {
+                            "id": "e6328152-bb29-4664-9dae-3bc7eaae1fd8",
+                            "name": "Email - Outlook REST API",
+                            "publisher": "Microsoft",
+                            "version": "22.3.0.0"
+                        }
                      ],
     "screenshots":  [
 

--- a/Apps/W1/HybridGP/app/src/Migration/History/GPPopulateHistTables.Codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/History/GPPopulateHistTables.Codeunit.al
@@ -89,7 +89,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::"GP GL00105";
-
+        GPGL00105.SetLoadFields(DEX_ROW_ID, ACTINDX, ACTNUMST);
         GPGL00105.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPGL00105.SetCurrentKey(DEX_ROW_ID);
         GPGL00105.SetAscending(DEX_ROW_ID, true);
@@ -134,7 +134,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::"GP GL20000";
-
+        GPGL20000.SetLoadFields(DEX_ROW_ID, OPENYEAR, ACTINDX, SERIES, SOURCDOC, JRNENTRY, SEQNUMBR, TRXSORCE, TRXDATE, CURNCYID, DEBITAMT, ORDBTAMT, CRDTAMNT, ORCRDAMT, SOURCDOC, REFRENCE, DSCRIPTN, ORTRXSRC, USWHPSTD, User_Defined_Text01, User_Defined_Text02, ORDOCNUM, ORMSTRID, ORMSTRNM);
         GPGL20000.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPGL20000.SetCurrentKey(DEX_ROW_ID);
         GPGL20000.SetAscending(DEX_ROW_ID, true);
@@ -207,7 +207,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::"GP GL30000";
-
+        GPGL30000.SetLoadFields(DEX_ROW_ID, HSTYEAR, ACTINDX, SERIES, SOURCDOC, JRNENTRY, SEQNUMBR, TRXSORCE, TRXDATE, CURNCYID, DEBITAMT, ORDBTAMT, CRDTAMNT, ORCRDAMT, SOURCDOC, REFRENCE, DSCRIPTN, ORTRXSRC, USWHPSTD, User_Defined_Text01, User_Defined_Text02, ORDOCNUM, ORMSTRID, ORMSTRNM);
         GPGL30000.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPGL30000.SetCurrentKey(DEX_ROW_ID);
         GPGL30000.SetAscending(DEX_ROW_ID, true);
@@ -290,7 +290,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::GPSOPTrxHist;
-
+        GPSOPTrxHist.SetLoadFields(DEX_ROW_ID, DOCDATE, SOPNUMBE, CUSTNMBR, SOPTYPE, SOPSTATUS, CURNCYID, SUBTOTAL, TAXAMNT, TRDISAMT, FRTAMNT, MISCAMNT, PYMTRCVD, DISTKNAM, DOCAMNT, DUEDATE, ACTLSHIP, CUSTNAME, SHIPMTHD, PRSTADCD, ShipToName, ADDRESS1, ADDRESS2, CITY, STATE, ZIPCODE, COUNTRY, CNTCPRSN, SLPRSNID, SALSTERR, CSTPONBR, ORIGNUMB, TRXSORCE);
         GPSOPTrxHist.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPSOPTrxHist.SetCurrentKey(DEX_ROW_ID);
         GPSOPTrxHist.SetAscending(DEX_ROW_ID, true);
@@ -356,11 +356,12 @@ codeunit 40900 "GP Populate Hist. Tables"
         AfterProcessedSection(SourceTableId, LastSourceRecordId);
     end;
 
-    local procedure PopulateSalesTransactionLines(GPSOPTrxHist: Record GPSOPTrxHist; DocumentNo: Code[35])
+    local procedure PopulateSalesTransactionLines(var GPSOPTrxHist: Record GPSOPTrxHist; DocumentNo: Code[35])
     var
         GPSOPTrxAmountsHist: Record GPSOPTrxAmountsHist;
         HistSalesTrxLine: Record "Hist. Sales Trx. Line";
     begin
+        GPSOPTrxAmountsHist.SetLoadFields(DEX_ROW_ID, SOPTYPE, SOPNUMBE, LNITMSEQ, CMPNTSEQ, ITEMNMBR, ITEMDESC, UOFM, UNITCOST, UNITPRCE, QUANTITY, EXTDCOST, XTNDPRCE, TAXAMNT, LOCNCODE, ShipToName);
         GPSOPTrxAmountsHist.SetRange(SOPTYPE, GPSOPTrxHist.SOPTYPE);
         GPSOPTrxAmountsHist.SetRange(SOPNUMBE, GPSOPTrxHist.SOPNUMBE);
         if not GPSOPTrxAmountsHist.FindSet() then
@@ -408,7 +409,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::"GP RM20101";
-
+        GPRM20101.SetLoadFields(DEX_ROW_ID, DOCDATE, CUSTNMBR, DOCNUMBR, RMDTYPAL, BACHNUMB, BCHSOURC, TRXSORCE, TRXDSCRN, DUEDATE, POSTDATE, PSTUSRID, CURNCYID, ORTRXAMT, CURTRXAM, SLSAMNT, COSTAMNT, FRTAMNT, MISCAMNT, TAXAMNT, DISTKNAM, CSPORNBR, SLPRSNID, SLSTERCD, SHIPMTHD, SHIPMTHD, CASHAMNT, COMDLRAM, DINVPDOF, PYMTRMID, WROFAMNT);
         GPRM20101.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPRM20101.SetCurrentKey(DEX_ROW_ID);
         GPRM20101.SetAscending(DEX_ROW_ID, true);
@@ -483,7 +484,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::GPRMHist;
-
+        GPRMHist.SetLoadFields(DEX_ROW_ID, DOCDATE, CUSTNMBR, DOCNUMBR, RMDTYPAL, BACHNUMB, BCHSOURC, TRXSORCE, TRXDSCRN, DUEDATE, POSTDATE, PSTUSRID, CURNCYID, ORTRXAMT, CURTRXAM, SLSAMNT, COSTAMNT, FRTAMNT, MISCAMNT, TAXAMNT, DISTKNAM, CSPORNBR, SLPRSNID, SLSTERCD, SHIPMTHD, SHIPMTHD, CASHAMNT, COMDLRAM, DINVPDOF, PYMTRMID, WROFAMNT);
         GPRMHist.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPRMHist.SetCurrentKey(DEX_ROW_ID);
         GPRMHist.SetAscending(DEX_ROW_ID, true);
@@ -569,7 +570,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::"GP PM20000";
-
+        GPPM20000.SetLoadFields(DEX_ROW_ID, DOCDATE, VENDORID, DOCTYPE, DOCNUMBR, VCHRNMBR, DOCAMNT, CURNCYID, CURTRXAM, DISTKNAM, BCHSOURC, BACHNUMB, DUEDATE, PORDNMBR, TRXSORCE, TRXDSCRN, POSTEDDT, PTDUSRID, MSCCHAMT, FRTAMNT, TAXAMNT, TTLPYMTS, VOIDED, DINVPDOF, SHIPMTHD, TEN99AMNT, WROFAMNT, TRDISAMT, PYMTRMID, TEN99TYPE, TEN99BOXNUMBER, PONUMBER);
         GPPM20000.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPPM20000.SetCurrentKey(DEX_ROW_ID);
         GPPM20000.SetAscending(DEX_ROW_ID, true);
@@ -646,7 +647,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         LastSourceRecordId: Integer;
     begin
         SourceTableId := Database::GPPMHist;
-
+        GPPMHist.SetLoadFields(DEX_ROW_ID, DOCDATE, VENDORID, DOCTYPE, DOCNUMBR, VCHRNMBR, DOCAMNT, CURNCYID, CURTRXAM, DISTKNAM, BCHSOURC, BACHNUMB, DUEDATE, PORDNMBR, TRXSORCE, TRXDSCRN, POSTEDDT, PTDUSRID, MSCCHAMT, FRTAMNT, TAXAMNT, TTLPYMTS, VOIDED, DINVPDOF, SHIPMTHD, TEN99AMNT, WROFAMNT, TRDISAMT, PYMTRMID, TEN99TYPE, TEN99BOXNUMBER, PONUMBER);
         GPPMHist.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPPMHist.SetCurrentKey(DEX_ROW_ID);
         GPPMHist.SetAscending(DEX_ROW_ID, true);
@@ -725,7 +726,7 @@ codeunit 40900 "GP Populate Hist. Tables"
             exit;
 
         SourceTableId := Database::GPIVTrxHist;
-
+        GPIVTrxHist.SetLoadFields(DEX_ROW_ID, DOCDATE, TRXSORCE, IVDOCTYP, DOCDATE, BACHNUMB, BCHSOURC, GLPOSTDT, SRCRFRNCNMBR, SOURCEINDICATOR);
         GPIVTrxHist.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPIVTrxHist.SetCurrentKey(DEX_ROW_ID);
         GPIVTrxHist.SetAscending(DEX_ROW_ID, true);
@@ -775,6 +776,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         GPIVTrxAmountsHist: Record GPIVTrxAmountsHist;
         HistInventoryTrxLine: Record "Hist. Inventory Trx. Line";
     begin
+        GPIVTrxAmountsHist.SetLoadFields(DEX_ROW_ID, TRXSORCE, DOCNUMBR, ITEMNMBR, CUSTNMBR, DOCTYPE, LNSEQNBR, DOCDATE, HSTMODUL, UOFM, TRXQTY, UNITCOST, EXTDCOST, TRXLOCTN, TRNSTLOC, Reason_Code);
         GPIVTrxAmountsHist.SetRange(TRXSORCE, AuditCode);
         GPIVTrxAmountsHist.SetRange(DOCNUMBR, DocumentNo);
 
@@ -823,7 +825,7 @@ codeunit 40900 "GP Populate Hist. Tables"
             exit;
 
         SourceTableId := Database::"GP BM30200";
-
+        GPBM30200.SetLoadFields(DEX_ROW_ID, TRXDATE, TRX_ID, TRXSORCE, BACHNUMB, BCHSOURC, PSTGDATE, REFRENCE);
         GPBM30200.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPBM30200.SetCurrentKey(DEX_ROW_ID);
         GPBM30200.SetAscending(DEX_ROW_ID, true);
@@ -880,7 +882,7 @@ codeunit 40900 "GP Populate Hist. Tables"
             exit;
 
         SourceTableId := Database::GPPOPReceiptHist;
-
+        GPPOPReceiptHist.SetLoadFields(DEX_ROW_ID, receiptdate, POPRCTNM, VENDORID, VENDNAME, POPTYPE, VNDDOCNM, GLPOSTDT, ACTLSHIP, BACHNUMB, SUBTOTAL, TRDISAMT, FRTAMNT, MISCAMNT, TAXAMNT, TEN99AMNT, PYMTRMID, DSCPCTAM, DSCDLRAM, DISAVAMT, DISCDATE, DUEDATE, REFRENCE, VOIDSTTS, PTDUSRID, TRXSORCE, VCHRNMBR, CURNCYID, InvoiceReceiptDate, PrepaymentAmount);
         GPPOPReceiptHist.SetFilter(DEX_ROW_ID, GetSourceTableRecIdFilter(SourceTableId));
         GPPOPReceiptHist.SetCurrentKey(DEX_ROW_ID);
         GPPOPReceiptHist.SetAscending(DEX_ROW_ID, true);
@@ -947,12 +949,13 @@ codeunit 40900 "GP Populate Hist. Tables"
         HistMigrationStatusMgmt.UpdateStepStatus("Hist. Migration Step Type"::"GP Purchase Receivables Trx.", true);
     end;
 
-    local procedure PopulatePurchaseRecvLines(GPPOPReceiptHist: Record GPPOPReceiptHist; ReceiptNo: Code[35])
+    local procedure PopulatePurchaseRecvLines(var GPPOPReceiptHist: Record GPPOPReceiptHist; ReceiptNo: Code[35])
     var
         GPPOPReceiptLineHist: Record GPPOPReceiptLineHist;
         GPPOPReceiptApply: Record GPPOPReceiptApply;
         HistPurchaseRecvLine: Record "Hist. Purchase Recv. Line";
     begin
+        GPPOPReceiptLineHist.SetLoadFields(DEX_ROW_ID, POPRCTNM, PONUMBER, ITEMNMBR, RCPTLNNM, ITEMDESC, VNDITNUM, VNDITDSC, UMQTYINB, ACTLSHIP, UOFM, UNITCOST, EXTDCOST, TAXAMNT, LOCNCODE, TRXSORCE, SHIPMTHD, ORUNTCST, OREXTCST, ORDISTKN, ORTDISAM, ORFRTAMT, ORMISCAMT);
         GPPOPReceiptLineHist.SetRange(POPRCTNM, GPPOPReceiptHist.POPRCTNM);
 
         if not GPPOPReceiptLineHist.FindSet() then
@@ -987,6 +990,7 @@ codeunit 40900 "GP Populate Hist. Tables"
             HistPurchaseRecvLine."Orig. Freight Amount" := GPPOPReceiptLineHist.ORFRTAMT;
             HistPurchaseRecvLine."Orig. Misc. Amount" := GPPOPReceiptLineHist.ORMISCAMT;
 
+            GPPOPReceiptApply.SetLoadFields(POPRCTNM, RCPTLNNM, QTYSHPPD, QTYINVCD);
             GPPOPReceiptApply.SetRange(POPRCTNM, GPPOPReceiptLineHist.POPRCTNM);
             GPPOPReceiptApply.SetRange(RCPTLNNM, GPPOPReceiptLineHist.RCPTLNNM);
             if GPPOPReceiptApply.FindFirst() then begin
@@ -1001,7 +1005,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         until GPPOPReceiptLineHist.Next() = 0;
     end;
 
-    local procedure PopulateGLOpenYearItemTransaction(GPGL20000: Record "GP GL20000")
+    local procedure PopulateGLOpenYearItemTransaction(var GPGL20000: Record "GP GL20000")
     var
         GPIVTrxAmountsHist: Record GPIVTrxAmountsHist;
         HistInventoryTrxHeader: Record "Hist. Inventory Trx. Header";
@@ -1020,6 +1024,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         DocumentNo := GPGL20000.REFRENCE.TrimEnd();
 #pragma warning restore AA0139
 
+        GPIVTrxAmountsHist.SetLoadFields(DEX_ROW_ID, TRXSORCE, DOCNUMBR, DOCTYPE);
         GPIVTrxAmountsHist.SetRange(TRXSORCE, GPGL20000.ORTRXSRC);
         GPIVTrxAmountsHist.SetRange(DOCNUMBR, DocumentNo);
         if not GPIVTrxAmountsHist.FindFirst() then
@@ -1047,7 +1052,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         AfterProcessedNextChildRecord();
     end;
 
-    local procedure PopulateGLHistoricalYearItemTransaction(GPGL30000: Record "GP GL30000")
+    local procedure PopulateGLHistoricalYearItemTransaction(var GPGL30000: Record "GP GL30000")
     var
         GPIVTrxAmountsHist: Record GPIVTrxAmountsHist;
         HistInventoryTrxHeader: Record "Hist. Inventory Trx. Header";
@@ -1066,6 +1071,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         DocumentNo := GPGL30000.REFRENCE.TrimEnd();
 #pragma warning restore AA0139
 
+        GPIVTrxAmountsHist.SetLoadFields(DEX_ROW_ID, TRXSORCE, DOCNUMBR, DOCTYPE);
         GPIVTrxAmountsHist.SetRange(TRXSORCE, GPGL30000.ORTRXSRC);
         GPIVTrxAmountsHist.SetRange(DOCNUMBR, DocumentNo);
         if not GPIVTrxAmountsHist.FindFirst() then
@@ -1093,7 +1099,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         AfterProcessedNextChildRecord();
     end;
 
-    local procedure PopulatePOPItemTransaction(GPPOPReceiptHist: Record GPPOPReceiptHist)
+    local procedure PopulatePOPItemTransaction(var GPPOPReceiptHist: Record GPPOPReceiptHist)
     var
         GPIVTrxAmountsHist: Record GPIVTrxAmountsHist;
         HistInventoryTrxHeader: Record "Hist. Inventory Trx. Header";
@@ -1102,6 +1108,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         if not GPCompanyAdditionalSettings.GetMigrateHistInvTrx() then
             exit;
 
+        GPIVTrxAmountsHist.SetLoadFields(TRXSORCE, DOCTYPE);
         GPIVTrxAmountsHist.SetRange(TRXSORCE, GPPOPReceiptHist.TRXSORCE);
 
         if not GPIVTrxAmountsHist.FindFirst() then
@@ -1127,7 +1134,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         AfterProcessedNextChildRecord();
     end;
 
-    local procedure PopulateSOPItemTransaction(GPSOPTrxHist: Record GPSOPTrxHist)
+    local procedure PopulateSOPItemTransaction(var GPSOPTrxHist: Record GPSOPTrxHist)
     var
         GPIVTrxAmountsHist: Record GPIVTrxAmountsHist;
         HistInventoryTrxHeader: Record "Hist. Inventory Trx. Header";
@@ -1136,6 +1143,7 @@ codeunit 40900 "GP Populate Hist. Tables"
         if not GPCompanyAdditionalSettings.GetMigrateHistInvTrx() then
             exit;
 
+        GPIVTrxAmountsHist.SetLoadFields(DEX_ROW_ID, TRXSORCE, DOCTYPE);
         GPIVTrxAmountsHist.SetRange(TRXSORCE, GPSOPTrxHist.TRXSORCE);
 
         if not GPIVTrxAmountsHist.FindFirst() then

--- a/Apps/W1/HybridGP/app/src/Migration/Support/EmailNotifications/GPMigrationEmailAddress.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/EmailNotifications/GPMigrationEmailAddress.Table.al
@@ -1,7 +1,7 @@
 table 41006 "GP Migration Email Address"
 {
     Caption = 'GP Migration Email Address';
-    DataClassification = ToBeClassified;
+    DataClassification = CustomerContent;
     DataPerCompany = false;
 
     fields

--- a/Apps/W1/HybridGP/app/src/Migration/Support/EmailNotifications/GPMigrationEmailAddress.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/EmailNotifications/GPMigrationEmailAddress.Table.al
@@ -1,0 +1,35 @@
+table 41006 "GP Migration Email Address"
+{
+    Caption = 'GP Migration Email Address';
+    DataClassification = ToBeClassified;
+    DataPerCompany = false;
+
+    fields
+    {
+        field(1; "Primary Key"; Integer)
+        {
+            AutoIncrement = true;
+            DataClassification = SystemMetadata;
+        }
+        field(2; "Email Address"; Text[250])
+        {
+            Caption = 'Email Address';
+            DataClassification = CustomerContent;
+
+            trigger OnValidate()
+            var
+                EmailAccount: Codeunit "Email Account";
+            begin
+                if not EmailAccount.ValidateEmailAddress(Rec."Email Address") then
+                    FieldError("Email Address", 'The email address is not valid.');
+            end;
+        }
+    }
+    keys
+    {
+        key(PK; "Primary Key")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/Apps/W1/HybridGP/app/src/Migration/Support/EmailNotifications/GPMigrationEmailAddresses.Page.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/EmailNotifications/GPMigrationEmailAddresses.Page.al
@@ -1,0 +1,56 @@
+page 44103 "GP Migration Email Addresses"
+{
+    ApplicationArea = All;
+    Caption = 'GP Migration Email Addresses';
+    PageType = List;
+    SourceTable = "GP Migration Email Address";
+    UsageCategory = Administration;
+    InsertAllowed = true;
+    DeleteAllowed = true;
+    ModifyAllowed = true;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field("Email Address"; Rec."Email Address")
+                {
+                    ToolTip = 'Specify the Email Address for migration notifications.';
+                }
+            }
+        }
+    }
+
+    actions
+    {
+        area(Processing)
+        {
+            action(TestEmail)
+            {
+                Caption = 'Test Notification';
+                ToolTip = 'Test Notification';
+                Promoted = true;
+                PromotedIsBig = true;
+                PromotedOnly = true;
+                PromotedCategory = Process;
+                Image = Email;
+
+                trigger OnAction()
+                var
+                    GPMigrationEmailAddress: Record "GP Migration Email Address";
+                    GPMigrationNotifier: Codeunit "GP Migration Notifier";
+                begin
+                    if GPMigrationEmailAddress.IsEmpty() then begin
+                        Message('No email addresses to send the notification to.');
+                        exit;
+                    end;
+
+                    GPMigrationNotifier.SendMigrationNotification("Migration Event Type"::"Test Notification");
+                    Message('Test sent');
+                end;
+            }
+        }
+    }
+}

--- a/Apps/W1/HybridGP/app/src/Migration/Support/EmailNotifications/GPMigrationNotifier.Codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/EmailNotifications/GPMigrationNotifier.Codeunit.al
@@ -1,0 +1,153 @@
+codeunit 40109 "GP Migration Notifier"
+{
+    procedure SendMigrationNotification(MigrationEventType: Enum "Migration Event Type")
+    begin
+        SendMigrationNotification(MigrationEventType, '');
+    end;
+
+    procedure SendMigrationNotification(MigrationEventType: Enum "Migration Event Type"; AdditionalText: Text)
+    var
+        GPMigrationEmailAddress: Record "GP Migration Email Address";
+        HybridCompanyStatus: Record "Hybrid Company Status";
+        EmailMessage: Codeunit "Email Message";
+        EnvironmentInformation: Codeunit "Environment Information";
+        TenantGuid: Text;
+        EnvironmentName: Text;
+        RecipientList: List of [Text];
+        RecipientCsv: Text;
+        Subject: Text;
+        Body: TextBuilder;
+    begin
+        if GPMigrationEmailAddress.FindSet() then
+            repeat
+                RecipientList.Add(GPMigrationEmailAddress."Email Address");
+
+                if RecipientCsv <> '' then
+                    RecipientCsv := RecipientCsv + ';';
+
+                RecipientCsv := RecipientCsv + GPMigrationEmailAddress."Email Address";
+            until GPMigrationEmailAddress.Next() = 0;
+
+        if RecipientList.Count() > 0 then begin
+            TenantGuid := TenantId();
+            EnvironmentName := EnvironmentInformation.GetEnvironmentName();
+            Subject := Text.StrSubstNo(SubjectLbl, EnvironmentName, MigrationEventType);
+            Body.Append('<div>');
+            Body.Append('<p><a href="' + System.GetUrl(ClientType::Web) + '">Go to ' + EnvironmentName + '</a></p>');
+            Body.Append('<p><b>Tenant Id:</b> ' + TenantGuid + '</p>');
+            Body.Append('<p><b>Environment:</b> ' + EnvironmentName + '</p>');
+            Body.Append('<p><b>Company:</b> ' + CompanyName() + '</p>');
+            Body.Append('<p><b>Date:</b> ' + Format(System.CurrentDateTime()) + '</p>');
+            Body.Append('<p><b>Status:</b> ' + Format(MigrationEventType) + '</p>');
+
+            if HybridCompanyStatus.FindSet() then begin
+                Body.Append('<h3>Per company status</h3>');
+                Body.Append('<ul>');
+                repeat
+                    Body.Append('<li>' + HybridCompanyStatus.Name + ' (' + Format(HybridCompanyStatus."Upgrade Status") + ')' + '</li>');
+                until HybridCompanyStatus.Next() = 0;
+                Body.Append('</ul>');
+            end;
+
+            if AdditionalText <> '' then begin
+                Body.Append('<h3>Additional Information</h3>');
+                Body.Append('<p>' + AdditionalText + '</p>');
+            end;
+            Body.Append('</div>');
+
+            EmailMessage.Create(RecipientCsv, Subject, Body.ToText(), true);
+            Send(EmailMessage, RecipientList);
+        end;
+    end;
+
+    procedure Send(EmailMessage: Codeunit "Email Message"; RecipientList: List of [Text])
+    var
+        EmailOutlookAPIClient: Codeunit "Email - Outlook API Client";
+        EmailOAuthClient: Codeunit "Email - OAuth Client";
+
+        [NonDebuggable]
+        AccessToken: Text;
+    begin
+        EmailOAuthClient.GetAccessToken(AccessToken);
+        EmailOutlookAPIClient.SendEmail(AccessToken, EmailMessageToJson(EmailMessage, RecipientList));
+    end;
+
+    local procedure EmailMessageToJson(var EmailMessage: Codeunit "Email Message"; RecipientList: List of [Text]): JsonObject
+    var
+        MessageJson: JsonObject;
+        MessageText: Text;
+        EmailBody: JsonObject;
+        EmailMessageJson: JsonObject;
+    begin
+        EmailMessageJson := CreateEmailMessageJson();
+
+        if EmailMessage.IsBodyHTMLFormatted() then
+            EmailBody.Add('contentType', 'HTML')
+        else
+            EmailBody.Add('contentType', 'text');
+
+        EmailBody.Add('content', EmailMessage.GetBody());
+
+        EmailMessageJson.Add('subject', EmailMessage.GetSubject());
+        EmailMessageJson.Add('body', EmailBody);
+        EmailMessageJson.Add('toRecipients', GetEmailRecipients(RecipientList));
+
+        EmailMessageJson.WriteTo(MessageText);
+
+        EmailMessageJson.WriteTo(MessageText);
+        MessageJson.Add('message', EmailMessageJson);
+        MessageJson.Add('saveToSentItems', true);
+
+        exit(MessageJson);
+    end;
+
+    local procedure GetEmailRecipients(RecipientList: List of [Text]): JsonArray
+    var
+        Address: JsonObject;
+        RecipientsJson: JsonArray;
+        EmailAddress: JsonObject;
+        Value: Text;
+    begin
+        foreach value in RecipientList do begin
+            clear(Address);
+            clear(EmailAddress);
+            Address.Add('address', value);
+            EmailAddress.Add('emailAddress', Address);
+            RecipientsJson.Add(EmailAddress);
+        end;
+        exit(RecipientsJson);
+    end;
+
+    local procedure CreateEmailMessageJson(): JsonObject
+    var
+        FromEmailAddress: Text[250];
+        EmailMessageJson: JsonObject;
+        EmailAddressJson: JsonObject;
+        FromJson: JsonObject;
+    begin
+        FromEmailAddress := GetCurrentUserEmailAddress();
+        if FromEmailAddress = '' then
+            Error('From email address cannot be empty!');
+
+        EmailAddressJson.Add('address', FromEmailAddress);
+        EmailAddressJson.Add('name', 'User');
+
+        FromJson.Add('emailAddress', EmailAddressJson);
+        EmailMessageJson.Add('from', FromJson);
+
+        exit(EmailMessageJson);
+    end;
+
+    local procedure GetCurrentUserEmailAddress(): Text[250]
+    var
+        User: Record User;
+    begin
+        if User.Get(Database.UserSecurityId()) then
+            exit(User."Contact Email");
+
+        exit('');
+    end;
+
+    var
+        SubjectLbl: Label '%1 migration status update: %2', Locked = true;
+}

--- a/Apps/W1/HybridGP/app/src/Migration/Support/EmailNotifications/MigrationEventType.Enum.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/EmailNotifications/MigrationEventType.Enum.al
@@ -1,0 +1,27 @@
+enum 40010 "Migration Event Type"
+{
+    value(0; "Test Notification")
+    {
+        Caption = 'Test Notification';
+    }
+    value(1; "Replication Started")
+    {
+        Caption = 'Replication Started';
+    }
+    value(2; "Replication Finished")
+    {
+        Caption = 'Replication Finished';
+    }
+    value(3; "Migration Started")
+    {
+        Caption = 'Migration Started';
+    }
+    value(4; "Migration Finished")
+    {
+        Caption = 'Migration Finished';
+    }
+    value(5; "Migration Failed")
+    {
+        Caption = 'Migration Failed';
+    }
+}

--- a/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/GPCloudMigration.codeunit.al
@@ -8,6 +8,7 @@ codeunit 4025 "GP Cloud Migration"
         AssistedCompanySetupStatus: Record "Assisted Company Setup Status";
         HelperFunctions: Codeunit "Helper Functions";
         HybridGPManagement: Codeunit "Hybrid GP Management";
+        GPMigrationNotifier: Codeunit "GP Migration Notifier";
         SetupStatus: Enum "Company Setup Status";
     begin
         if AssistedCompanySetupStatus.Get(CompanyName()) then begin
@@ -30,6 +31,8 @@ codeunit 4025 "GP Cloud Migration"
             HybridGPManagement.InvokeCompanyUpgrade(Rec, HybridCompanyStatus.Name);
             exit;
         end;
+
+        GPMigrationNotifier.SendMigrationNotification("Migration Event Type"::"Migration Finished");
 
         if Rec.Find() then begin
             Rec.Status := Rec.Status::Completed;

--- a/Apps/W1/HybridGP/app/src/codeunits/HybridHandleGPUpgradeError.Codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/HybridHandleGPUpgradeError.Codeunit.al
@@ -5,17 +5,23 @@ codeunit 40020 "Hybrid Handle GP Upgrade Error"
     trigger OnRun()
     var
         HybridCompanyStatus: Record "Hybrid Company Status";
+        GPMigrationNotifier: Codeunit "GP Migration Notifier";
         FailureMessageOutStream: OutStream;
+        ErrorText: Text;
     begin
         HybridCompanyStatus.Get(CompanyName);
         HybridCompanyStatus."Upgrade Status" := HybridCompanyStatus."Upgrade Status"::Failed;
         HybridCompanyStatus."Upgrade Failure Message".CreateOutStream(FailureMessageOutStream);
-        FailureMessageOutStream.Write(GetLastErrorText());
+
+        ErrorText := GetLastErrorText();
+        FailureMessageOutStream.Write(ErrorText);
         HybridCompanyStatus.Modify();
         Commit();
 
         Rec.Find();
         Rec.Status := Rec.Status::UpgradeFailed;
         Rec.Modify();
+
+        GPMigrationNotifier.SendMigrationNotification("Migration Event Type"::"Migration Failed", ErrorText);
     end;
 }

--- a/Apps/W1/HybridGP/app/src/pages/IntelligentCloudExtension.PageExt.al
+++ b/Apps/W1/HybridGP/app/src/pages/IntelligentCloudExtension.PageExt.al
@@ -19,6 +19,21 @@ pageextension 4015 "Intelligent Cloud Extension" extends "Intelligent Cloud Mana
 
     actions
     {
+        modify(RunReplicationNow)
+        {
+            trigger OnAfterAction()
+            var
+                GPMigrationNotifier: Codeunit "GP Migration Notifier";
+            begin
+                GPMigrationNotifier.SendMigrationNotification("Migration Event Type"::"Replication Started");
+            end;
+        }
+
+        modify(RunDataUpgrade)
+        {
+            Visible = false;
+        }
+
         addafter(RunReplicationNow)
         {
             action(ConfigureGPMigration)
@@ -72,6 +87,23 @@ pageextension 4015 "Intelligent Cloud Extension" extends "Intelligent Cloud Mana
                         WizardIntegration.ScheduleGPHistoricalSnapshotMigration();
                         Message(SnapshotJobRunningMsg);
                     end;
+                end;
+            }
+
+            action(EmailNotifications)
+            {
+                ApplicationArea = All;
+                Caption = 'Email Notifications';
+                ToolTip = 'Manage who gets notified with migration notifications.';
+                Promoted = true;
+                PromotedIsBig = true;
+                PromotedOnly = true;
+                PromotedCategory = Process;
+                Image = Email;
+
+                trigger OnAction()
+                begin
+                    Page.Run(Page::"GP Migration Email Addresses");
                 end;
             }
         }


### PR DESCRIPTION
**Auto Run Data Upgrade**
Automatically begin the data transformation phase of the migration after replication is finished and hide the Run Data Upgrade Now button.

**Migration event emails**
New action button on management screen "Email Notifications". On this screen, the user can add (also modify and delete) email addresses and test the sending of a notification with the "Test Notification" button.

No notifications are attempted if there are no email addresses added on the "Email Notifications" page. 

Send migration notification emails when:
- Replication Started
- Migration Started (per company)
- Migration Finished
- Migration Failed (includes error text)

**History Snapshot performance**
Added SetLoadFields to all queries to only load the needed fields in memory. I also added the var keyword for record parameters to allow them to be passed by reference, which is also considered best practice for performance.