### PR TITLE
Remove appended BC doc number to External Document No. field in AP and AR documents

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
@@ -117,7 +117,7 @@ codeunit 4018 "GP Customer Migrator"
                     Sender.CreatePaymentTermsIfNeeded(Copystr(MigrationGPCustTrans.PYMTRMID, 1, 10), MigrationGPCustTrans.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(MigrationGPCustTrans.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR, 1, 20) + '-' + CopyStr(MigrationGPCustTrans.GLDocNo, 1, 14));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR, 1, 35));
             until MigrationGPCustTrans.Next() = 0;
 
         MigrationGPCustTrans.Reset();
@@ -145,7 +145,7 @@ codeunit 4018 "GP Customer Migrator"
                     Sender.CreatePaymentTermsIfNeeded(Copystr(MigrationGPCustTrans.PYMTRMID, 1, 10), MigrationGPCustTrans.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(MigrationGPCustTrans.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR, 1, 20) + '-' + CopyStr(MigrationGPCustTrans.GLDocNo, 1, 14));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR, 1, 35));
             until MigrationGPCustTrans.Next() = 0;
 
         MigrationGPCustTrans.Reset();
@@ -174,7 +174,7 @@ codeunit 4018 "GP Customer Migrator"
                     Sender.CreatePaymentTermsIfNeeded(Copystr(MigrationGPCustTrans.PYMTRMID, 1, 10), MigrationGPCustTrans.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(MigrationGPCustTrans.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR, 1, 20) + '-' + CopyStr(MigrationGPCustTrans.GLDocNo, 1, 14));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR, 1, 35));
             until MigrationGPCustTrans.Next() = 0;
     end;
 #pragma warning restore AA0207

--- a/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Customers/GPCustomerMigrator.codeunit.al
@@ -117,7 +117,7 @@ codeunit 4018 "GP Customer Migrator"
                     Sender.CreatePaymentTermsIfNeeded(Copystr(MigrationGPCustTrans.PYMTRMID, 1, 10), MigrationGPCustTrans.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(MigrationGPCustTrans.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR, 1, 35));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR.Trim(), 1, 35));
             until MigrationGPCustTrans.Next() = 0;
 
         MigrationGPCustTrans.Reset();
@@ -145,7 +145,7 @@ codeunit 4018 "GP Customer Migrator"
                     Sender.CreatePaymentTermsIfNeeded(Copystr(MigrationGPCustTrans.PYMTRMID, 1, 10), MigrationGPCustTrans.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(MigrationGPCustTrans.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR, 1, 35));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR.Trim(), 1, 35));
             until MigrationGPCustTrans.Next() = 0;
 
         MigrationGPCustTrans.Reset();
@@ -174,7 +174,7 @@ codeunit 4018 "GP Customer Migrator"
                     Sender.CreatePaymentTermsIfNeeded(Copystr(MigrationGPCustTrans.PYMTRMID, 1, 10), MigrationGPCustTrans.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(MigrationGPCustTrans.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR, 1, 35));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(MigrationGPCustTrans.DOCNUMBR.Trim(), 1, 35));
             until MigrationGPCustTrans.Next() = 0;
     end;
 #pragma warning restore AA0207

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -119,7 +119,7 @@ codeunit 4022 "GP Vendor Migrator"
                     Sender.CreatePaymentTermsIfNeeded(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10), GPVendorTransactions.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR, 1, 35));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR.Trim(), 1, 35));
             until GPVendorTransactions.Next() = 0;
 
         GPVendorTransactions.Reset();
@@ -145,7 +145,7 @@ codeunit 4022 "GP Vendor Migrator"
                     Sender.CreatePaymentTermsIfNeeded(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10), GPVendorTransactions.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR, 1, 35));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR.Trim(), 1, 35));
             until GPVendorTransactions.Next() = 0;
 
         GPVendorTransactions.Reset();
@@ -171,7 +171,7 @@ codeunit 4022 "GP Vendor Migrator"
                     Sender.CreatePaymentTermsIfNeeded(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10), GPVendorTransactions.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR, 1, 35));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR.Trim(), 1, 35));
             until GPVendorTransactions.Next() = 0;
     end;
 #pragma warning restore AA0207

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -119,7 +119,7 @@ codeunit 4022 "GP Vendor Migrator"
                     Sender.CreatePaymentTermsIfNeeded(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10), GPVendorTransactions.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR, 1, 20) + '-' + CopyStr(GPVendorTransactions.GLDocNo, 1, 14));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR, 1, 35));
             until GPVendorTransactions.Next() = 0;
 
         GPVendorTransactions.Reset();
@@ -145,7 +145,7 @@ codeunit 4022 "GP Vendor Migrator"
                     Sender.CreatePaymentTermsIfNeeded(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10), GPVendorTransactions.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR, 1, 20) + '-' + CopyStr(GPVendorTransactions.GLDocNo, 1, 14));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR, 1, 35));
             until GPVendorTransactions.Next() = 0;
 
         GPVendorTransactions.Reset();
@@ -171,7 +171,7 @@ codeunit 4022 "GP Vendor Migrator"
                     Sender.CreatePaymentTermsIfNeeded(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10), GPVendorTransactions.PYMTRMID, PaymentTermsFormula);
                 end;
                 Sender.SetGeneralJournalLinePaymentTerms(CopyStr(GPVendorTransactions.PYMTRMID, 1, 10));
-                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR, 1, 20) + '-' + CopyStr(GPVendorTransactions.GLDocNo, 1, 14));
+                Sender.SetGeneralJournalLineExternalDocumentNo(CopyStr(GPVendorTransactions.DOCNUMBR, 1, 35));
             until GPVendorTransactions.Next() = 0;
     end;
 #pragma warning restore AA0207


### PR DESCRIPTION
Currently the migration tool appends the Document No. that is assigned to the migrated AP and AR transactions to the end of the External Doc. No. field.  The External Doc No. field is populated with the Doc number from GP.   Feedback has been provided by Partners and Customers that this causes confusion, is unnecessary and can break integrations.

This feature will remove the appended number from the External Doc number for both AR and AP transactions that are created during the migration.

[Product Backlog Item 9414](https://dev.azure.com/EPS-Product/EPS-Product/_workitems/edit/9414): Remove appended BC doc number to External Document No. field in AP and AR documents