### PR TITLE
Additional updates to Vendor Bank Account

### DIFF
--- a/Apps/US/HybridGP_US/app/src/Codeunits/GPCloudMigrationUS.Codeunit.al
+++ b/Apps/US/HybridGP_US/app/src/Codeunits/GPCloudMigrationUS.Codeunit.al
@@ -19,6 +19,24 @@ codeunit 42004 "GP Cloud Migration US"
         if GPCompanyAdditionalSettings.GetMigrateVendor1099Enabled() then begin
             BindSubscription(GPPopulateVendor1099Data);
             GPPopulateVendor1099Data.Run();
-        end
+            UnbindSubscription(GPPopulateVendor1099Data);
+        end;
+
+        SetPreferredVendorBankAccountsUseForElectronicPayments();
+    end;
+
+    local procedure SetPreferredVendorBankAccountsUseForElectronicPayments()
+    var
+        Vendor: Record Vendor;
+        VendorBankAccount: Record "Vendor Bank Account";
+    begin
+        Vendor.SetFilter("Preferred Bank Account Code", '<>%1', '');
+        if Vendor.FindSet() then
+            repeat
+                if VendorBankAccount.Get(Vendor."No.", Vendor."Preferred Bank Account Code") then begin
+                    VendorBankAccount.Validate("Use for Electronic Payments", true);
+                    VendorBankAccount.Modify();
+                end;
+            until Vendor.Next() = 0;
     end;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Vendors/GPVendorMigrator.codeunit.al
@@ -569,6 +569,7 @@ codeunit 4022 "GP Vendor Migrator"
     procedure MigrateVendorEFTBankAccounts()
     var
         GPSY06000: Record "GP SY06000";
+        CounterGPSY06000: Record "GP SY06000";
         Vendor: Record Vendor;
         VendorBankAccount: Record "Vendor Bank Account";
         GeneralLedgerSetup: Record "General Ledger Setup";
@@ -576,14 +577,30 @@ codeunit 4022 "GP Vendor Migrator"
         VendorBankAccountExists: Boolean;
         CurrencyCode: Code[10];
         IBANCode: Code[50];
+        LastVendorNo: Code[20];
+        VendorBankAccountCounter: Integer;
+        TotalVendorBankAccounts: Integer;
+        BankCode: Code[20];
     begin
+        GPSY06000.SetCurrentKey(CustomerVendor_ID);
         GPSY06000.SetRange("INACTIVE", false);
         if not GPSY06000.FindSet() then
             exit;
 
+        Clear(LastVendorNo);
         repeat
             Clear(VendorBankAccount);
             if Vendor.Get(GPSY06000.CustomerVendor_ID) then begin
+                if (Vendor."No." = LastVendorNo) then
+                    VendorBankAccountCounter := VendorBankAccountCounter + 1
+                else begin
+                    VendorBankAccountCounter := 1;
+                    CounterGPSY06000.SetRange(CustomerVendor_ID, Vendor."No.");
+                    CounterGPSY06000.SetRange("INACTIVE", false);
+                    TotalVendorBankAccounts := CounterGPSY06000.Count();
+                end;
+
+                LastVendorNo := Vendor."No.";
                 CurrencyCode := CopyStr(GPSY06000.CURNCYID, 1, MaxStrLen(CurrencyCode));
                 HelperFunctions.CreateCurrencyIfNeeded(CurrencyCode);
                 CreateSwiftCodeIfNeeded(GPSY06000.SWIFTADDR);
@@ -592,12 +609,13 @@ codeunit 4022 "GP Vendor Migrator"
                 if not IsValidIBANCode(IBANCode) then
                     IBANCode := '';
 
-                VendorBankAccountExists := VendorBankAccount.Get(Vendor."No.", GPSY06000.EFTBankCode);
+                BankCode := GetBankAccountCode(Vendor."No.", VendorBankAccountCounter, TotalVendorBankAccounts);
+                VendorBankAccountExists := VendorBankAccount.Get(Vendor."No.", BankCode);
                 VendorBankAccount.Validate("Vendor No.", Vendor."No.");
-                VendorBankAccount.Validate("Code", GPSY06000.EFTBankCode);
+                VendorBankAccount.Validate("Code", BankCode);
                 VendorBankAccount.Validate("Name", GPSY06000.BANKNAME);
                 VendorBankAccount.Validate("Bank Branch No.", GPSY06000.EFTBankBranchCode);
-                VendorBankAccount.Validate("Bank Account No.", CopyStr(GPSY06000.EFTBankAcct, 1, 30));
+                VendorBankAccount.Validate("Bank Account No.", CopyStr(GPSY06000.EFTBankAcct, 1, MaxStrLen(VendorBankAccount."Bank Account No.")));
                 VendorBankAccount.Validate("Transit No.", GPSY06000.EFTTransitRoutingNo);
                 VendorBankAccount.Validate("IBAN", IBANCode);
                 VendorBankAccount.Validate("SWIFT Code", GPSY06000.SWIFTADDR);
@@ -611,9 +629,43 @@ codeunit 4022 "GP Vendor Migrator"
                 else
                     VendorBankAccount.Modify();
 
-                SetPreferredBankAccountIfNeeded(GPSY06000, Vendor);
+                SetPreferredBankAccountIfNeeded(GPSY06000, Vendor, BankCode, TotalVendorBankAccounts);
             end;
         until GPSY06000.Next() = 0;
+    end;
+
+    local procedure GetBankAccountCode(VendorNo: Code[20]; var BankAccountCounter: Integer; TotalVendorBankAccounts: Integer): Code[20]
+    var
+        BankCode: Code[20];
+        MaxSupportedVendorNoLength: Integer;
+    begin
+        if TotalVendorBankAccounts = 1 then
+            exit(VendorNo);
+
+        // Prevent over flow
+        MaxSupportedVendorNoLength := MaxStrLen(BankCode) - StrLen(Format(TotalVendorBankAccounts)) - 1;
+#pragma warning disable AA0139
+        if StrLen(VendorNo) > MaxSupportedVendorNoLength then
+            VendorNo := CopyStr(VendorNo, 1, MaxSupportedVendorNoLength);
+#pragma warning restore AA0139
+
+        // The Vendor has more than one account, append a number to the code
+        BankCode := CopyStr(VendorNo + '-' + Format(BankAccountCounter), 1, MaxStrLen(BankCode));
+        while BankAccountAlreadyExists(VendorNo, BankCode) do begin
+            BankAccountCounter := BankAccountCounter + 1;
+            BankCode := CopyStr(VendorNo + '-' + Format(BankAccountCounter), 1, MaxStrLen(BankCode));
+        end;
+
+        exit(BankCode);
+    end;
+
+    local procedure BankAccountAlreadyExists(VendorNo: Code[20]; BankCode: Code[20]): Boolean
+    var
+        VendorBankAccount: Record "Vendor Bank Account";
+    begin
+        VendorBankAccount.SetRange("Vendor No.", VendorNo);
+        VendorBankAccount.SetRange(Code, BankCode);
+        exit(not VendorBankAccount.IsEmpty());
     end;
 
     local procedure IsValidIBANCode(IBANCode: Code[100]): Boolean
@@ -652,7 +704,7 @@ codeunit 4022 "GP Vendor Migrator"
         end;
     end;
 
-    local procedure SetPreferredBankAccountIfNeeded(GPSY06000: Record "GP SY06000"; var Vendor: Record Vendor)
+    local procedure SetPreferredBankAccountIfNeeded(GPSY06000: Record "GP SY06000"; var Vendor: Record Vendor; NewBankCode: Code[20]; TotalVendorBankAccounts: Integer)
     var
         SearchGPSY06000: Record "GP SY06000";
         GPPM00200: Record "GP PM00200";
@@ -680,8 +732,8 @@ codeunit 4022 "GP Vendor Migrator"
                 end;
         end;
 
-        if ShouldSetAsPrimaryAccount then begin
-            Vendor.Validate(Vendor."Preferred Bank Account Code", GPSY06000.EFTBankCode);
+        if ShouldSetAsPrimaryAccount or (TotalVendorBankAccounts = 1) then begin
+            Vendor.Validate(Vendor."Preferred Bank Account Code", NewBankCode);
             Vendor.Modify(true);
         end;
     end;

--- a/Apps/W1/HybridGP/test/src/GPDataMigrationTests.codeunit.al
+++ b/Apps/W1/HybridGP/test/src/GPDataMigrationTests.codeunit.al
@@ -965,6 +965,7 @@ codeunit 139664 "GP Data Migration Tests"
         VendorBankAccountCount: Integer;
         ActiveVendorBankAccountCount: Integer;
     begin
+#pragma warning disable AA0210
         VendorBankAccountCount := 10;
         ActiveVendorBankAccountCount := 9;
 
@@ -1023,11 +1024,11 @@ codeunit 139664 "GP Data Migration Tests"
         // [THEN] The fields for Vendors 1 are correctly applied
         Clear(VendorBankAccount);
         VendorBankAccount.SetRange("Vendor No.", VendorIdWithBankStr1Txt);
-        VendorBankAccount.SetRange(Code, 'V01_REMITTO');
+        VendorBankAccount.SetRange("Name", 'V01_RemitTo_Name');
         VendorBankAccount.FindFirst();
 
         Assert.AreEqual(VendorIdWithBankStr1Txt, VendorBankAccount."Vendor No.", 'Vendor No. of VendorBankAccount is wrong.');
-        Assert.AreEqual('V01_REMITTO', VendorBankAccount.Code, 'Code of VendorBankAccount is wrong.');
+        Assert.IsTrue(StrPos(VendorBankAccount.Code, '-') > 0, 'Vendor Bank Account Code missing dash (-).');
         Assert.AreEqual('V01_RemitTo_Name', VendorBankAccount.Name, 'Name of VendorBankAccount is wrong.');
         Assert.AreEqual('01234', VendorBankAccount."Bank Branch No.", 'Bank Branch No. of VendorBankAccount is wrong.');
         Assert.AreEqual('123456789', VendorBankAccount."Bank Account No.", 'Bank Account No. of VendorBankAccount is wrong.');
@@ -1042,7 +1043,9 @@ codeunit 139664 "GP Data Migration Tests"
         Vendor.FindFirst();
 
         // [THEN] The Remit To bank account will be the Vendor's preferred bank account
-        Assert.AreEqual('V01_REMITTO', Vendor."Preferred Bank Account Code", 'Preferred Bank Account Code of migrated Vendor should be Remit To account.');
+        Clear(VendorBankAccount);
+        VendorBankAccount.Get(Vendor."No.", Vendor."Preferred Bank Account Code");
+        Assert.AreEqual('V01_RemitTo_Name', VendorBankAccount.Name, 'Preferred Bank Account Code of migrated Vendor should be the Remit To account.');
 
         // [WHEN] The Vendor does not have a Remit To bank account, but has a Primary bank account
         Clear(Vendor);
@@ -1050,7 +1053,9 @@ codeunit 139664 "GP Data Migration Tests"
         Vendor.FindFirst();
 
         // [THEN] The Primary bank account will be the Vendor's preferred bank account
-        Assert.AreEqual('V02_PRIMARY', Vendor."Preferred Bank Account Code", 'Preferred Bank Account Code of migrated Vendor should be Primary account.');
+        Clear(VendorBankAccount);
+        VendorBankAccount.Get(Vendor."No.", Vendor."Preferred Bank Account Code");
+        Assert.AreEqual('V02_Primary_Name', VendorBankAccount.Name, 'Preferred Bank Account Code of migrated Vendor should be the Primary account.');
 
         // [WHEN] The Vendor does not have either a Remit To or Primary bank account
         Clear(Vendor);
@@ -1066,7 +1071,9 @@ codeunit 139664 "GP Data Migration Tests"
         Vendor.FindFirst();
 
         // [THEN] The Primary bank account will be the Vendor's preferred bank account
-        Assert.AreEqual('V04_PRIMARY', Vendor."Preferred Bank Account Code", 'Preferred Bank Account Code of migrated Vendor should be Primary account.');
+        Clear(VendorBankAccount);
+        VendorBankAccount.Get(Vendor."No.", Vendor."Preferred Bank Account Code");
+        Assert.AreEqual('V04_Primary_Name', VendorBankAccount.Name, 'Preferred Bank Account Code of migrated Vendor should be the Primary account.');
 
         // [WHEN] The Vendor Bank Accounts are created
         // [THEN] The IBAN field will get populated only if it passed validation checks
@@ -1074,42 +1081,43 @@ codeunit 139664 "GP Data Migration Tests"
         // Vendor 2, V02_Primary - Invalid IBAN
         Clear(VendorBankAccount);
         VendorBankAccount.SetRange("Vendor No.", VendorIdWithBankStr2Txt);
-        VendorBankAccount.SetRange(Code, 'V02_Primary');
+        VendorBankAccount.SetRange("Name", 'V02_Primary_Name');
         VendorBankAccount.FindFirst();
 
         Assert.AreEqual(VendorIdWithBankStr2Txt, VendorBankAccount."Vendor No.", 'Vendor No. of VendorBankAccount is wrong.');
-        Assert.AreEqual('V02_PRIMARY', VendorBankAccount.Code, 'Code of VendorBankAccount is wrong.');
+        Assert.IsTrue(StrPos(VendorBankAccount.Code, '-') > 0, 'Vendor Bank Account Code not generated in the correct format.');
         Assert.AreEqual('', VendorBankAccount.IBAN, 'IBAN of VendorBankAccount should be empty because it was invalid. V02_PRIMARY');
 
         // Vendor 2, V02_Other - Valid IBAN
         Clear(VendorBankAccount);
         VendorBankAccount.SetRange("Vendor No.", VendorIdWithBankStr2Txt);
-        VendorBankAccount.SetRange(Code, 'V02_Other');
+        VendorBankAccount.SetRange("Name", 'V02_Other_Name');
         VendorBankAccount.FindFirst();
 
         Assert.AreEqual(VendorIdWithBankStr2Txt, VendorBankAccount."Vendor No.", 'Vendor No. of VendorBankAccount is wrong.');
-        Assert.AreEqual('V02_OTHER', VendorBankAccount.Code, 'Code of VendorBankAccount is wrong.');
+        Assert.IsTrue(StrPos(VendorBankAccount.Code, '-') > 0, 'Vendor Bank Account Code not generated in the correct format.');
         Assert.AreEqual(ValidIBANStrTxt, VendorBankAccount.IBAN, 'IBAN of VendorBankAccount is wrong. V02_OTHER');
 
         // Vendor 3, V03_Other2 - Invalid IBAN
         Clear(VendorBankAccount);
         VendorBankAccount.SetRange("Vendor No.", VendorIdWithBankStr3Txt);
-        VendorBankAccount.SetRange(Code, 'V03_Other2');
+        VendorBankAccount.SetRange("Name", 'V03_Other2_Name');
         VendorBankAccount.FindFirst();
 
         Assert.AreEqual(VendorIdWithBankStr3Txt, VendorBankAccount."Vendor No.", 'Vendor No. of VendorBankAccount is wrong.');
-        Assert.AreEqual('V03_OTHER2', VendorBankAccount.Code, 'Code of VendorBankAccount is wrong.');
+        Assert.IsTrue(StrPos(VendorBankAccount.Code, '-') > 0, 'Vendor Bank Account Code not generated in the correct format.');
         Assert.AreEqual('', VendorBankAccount.IBAN, 'IBAN of VendorBankAccount should be empty because it was invalid. V03_OTHER2');
 
         // Vendor 3, V03_Other - Valid IBAN
         Clear(VendorBankAccount);
         VendorBankAccount.SetRange("Vendor No.", VendorIdWithBankStr3Txt);
-        VendorBankAccount.SetRange(Code, 'V03_Other');
+        VendorBankAccount.SetRange("Name", 'V03_Other_Name');
         VendorBankAccount.FindFirst();
 
         Assert.AreEqual(VendorIdWithBankStr3Txt, VendorBankAccount."Vendor No.", 'Vendor No. of VendorBankAccount is wrong.');
-        Assert.AreEqual('V03_OTHER', VendorBankAccount.Code, 'Code of VendorBankAccount is wrong.');
+        Assert.IsTrue(StrPos(VendorBankAccount.Code, '-') > 0, 'Vendor Bank Account Code not generated in the correct format.');
         Assert.AreEqual(ValidIBANStrTxt, VendorBankAccount.IBAN, 'IBAN of VendorBankAccount is wrong. V03_OTHER');
+#pragma warning restore AA0210
     end;
 
     [Test]
@@ -1191,7 +1199,7 @@ codeunit 139664 "GP Data Migration Tests"
         VendorPostingGroup.Get('USA-US-M');
         Assert.AreEqual('USA-US-M', VendorPostingGroup.Code, 'Code of VendorPostingGroup is incorrect.');
         Assert.AreEqual('U.S. Vendors-Misc. Expenses', VendorPostingGroup.Description, 'Description of VendorPostingGroup is incorrect.');
-        Assert.AreEqual('', VendorPostingGroup."Payables Account", 'Payables Account of VendorPostingGroup is incorrect.');
+        Assert.AreEqual('1', VendorPostingGroup."Payables Account", 'Payables Account of VendorPostingGroup is incorrect.');
         Assert.AreEqual('', VendorPostingGroup."Service Charge Acc.", 'Service Charge Acc. of VendorPostingGroup is incorrect.');
         Assert.AreEqual('', VendorPostingGroup."Payment Disc. Debit Acc.", 'Payment Disc. Debit Acc. of VendorPostingGroup is incorrect.');
         Assert.AreEqual('', VendorPostingGroup."Payment Disc. Credit Acc.", 'Payment Disc. Credit Acc. of VendorPostingGroup is incorrect.');


### PR DESCRIPTION
This change updates the logic around creating Vendor Bank accounts.

- Always rename the bank code to Vendor No. and append a number if there are multiple accounts.
- If only one account, don't append number and assign it as the preferred Vendor bank account.
- If the Vendor No. is 20 characters in length (max size), the resulting bank code will use the first 18 characters of the Vendor No. 
- Update the US extension to update the 'Use for electronic payments' for all preferred Vendor bank accounts.