### PR TITLE
Limit Fiscal Periods

### DIFF
--- a/Apps/W1/HybridGP/app/src/codeunits/FiscalPeriods.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/FiscalPeriods.codeunit.al
@@ -1,10 +1,15 @@
 codeunit 40107 FiscalPeriods
 {
-
     procedure MoveStagingData()
     var
         GPSY40101: Record "GP SY40101";
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        InitialYear: Integer;
     begin
+        InitialYear := GPCompanyAdditionalSettings.GetInitialYear();
+        if InitialYear > 0 then
+            GPSY40101.SetFilter(YEAR1, '>= %1', InitialYear);
+
         if not GPSY40101.FindSet() then
             exit;
 
@@ -35,7 +40,7 @@ codeunit 40107 FiscalPeriods
                 AccountingPeriod.Validate("Starting Date", DT2Date(OutlookSynchTypeConv.LocalDT2UTC(GPSY40100.PERIODDT)));
 
                 if not AccountingPeriod.Get() then begin
-                    AccountingPeriod.Validate(Name, CopyStr(GPSY40100.PERNAME.TrimEnd(), 1, 10));
+                    AccountingPeriod.Validate(Name, CopyStr(GPSY40100.PERNAME.TrimEnd(), 1, MaxStrLen(AccountingPeriod.Name)));
                     if I = 1 then begin
                         AccountingPeriod."New Fiscal Year" := true;
                         InventorySetup.Get();


### PR DESCRIPTION
Use the "Oldest GL Year to Migrate" setting to also limit the Accounting Periods created in BC.