### PR TITLE
Add additional information to checkbook/bank transactions

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Support/CheckBooks/GPCheckbookMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/CheckBooks/GPCheckbookMigrator.codeunit.al
@@ -49,7 +49,7 @@ codeunit 40025 "GP Checkbook Migrator"
             exit;
 
         if Amount <> 0.00 then
-            CreateGeneralJournalLine('BBF', DescriptionTxt, TrxDate, PostingAccountNumber, Amount, BankAccountNo);
+            CreateGeneralJournalLine('BBF', DescriptionTxt, '', TrxDate, PostingAccountNumber, Amount, BankAccountNo);
 
         MoveTransactionsData(BankAccountNo, BankAccPostingGroupCode, CheckbookID);
     end;
@@ -58,6 +58,9 @@ codeunit 40025 "GP Checkbook Migrator"
     var
         GPCheckbookTransactions: Record "GP Checkbook Transactions";
         PostingAccountNumber: Code[20];
+        DocumentNo: Code[20];
+        Description: Text[100];
+        ExternalDocumentNo: Code[35];
         Amount: Decimal;
     begin
         GPCheckbookTransactions.SetRange(CHEKBKID, CheckbookID);
@@ -79,8 +82,10 @@ codeunit 40025 "GP Checkbook Migrator"
                 if IsNegativeAmount(GPCheckbookTransactions.CMRECNUM, GPCheckbookTransactions.CMTrxNum) then
                     Amount := -GPCheckbookTransactions.TRXAMNT;
 
-            CreateGeneralJournalLine(Format(GPCheckbookTransactions.CMRECNUM), GPCheckbookTransactions.DSCRIPTN,
-                                        GPCheckbookTransactions.TRXDATE, PostingAccountNumber, Amount, BankAccountNo);
+            DocumentNo := CopyStr(GPCheckbookTransactions.CMTrxNum.Trim(), 1, MaxStrLen(DocumentNo));
+            Description := CopyStr(GPCheckbookTransactions.paidtorcvdfrom.Trim(), 1, MaxStrLen(Description));
+            ExternalDocumentNo := CopyStr(GPCheckbookTransactions.CMLinkID.Trim(), 1, MaxStrLen(ExternalDocumentNo));
+            CreateGeneralJournalLine(DocumentNo, Description, ExternalDocumentNo, GPCheckbookTransactions.TRXDATE, PostingAccountNumber, Amount, BankAccountNo);
         until GPCheckbookTransactions.Next() = 0;
     end;
 
@@ -148,7 +153,7 @@ codeunit 40025 "GP Checkbook Migrator"
         exit(Format(LastCheckNumber));
     end;
 
-    local procedure CreateGeneralJournalLine(DocumentNo: Code[20]; Description: Text[50]; PostingDate: Date; OffsetAccount: Code[20]; TrxAmount: Decimal; BankAccount: Code[20])
+    local procedure CreateGeneralJournalLine(DocumentNo: Code[20]; Description: Text[100]; ExternalDocumentNo: Code[35]; PostingDate: Date; OffsetAccount: Code[20]; TrxAmount: Decimal; BankAccount: Code[20])
     var
         GenJournalLine: Record "Gen. Journal Line";
         GenJournalLineCurrent: Record "Gen. Journal Line";
@@ -176,6 +181,7 @@ codeunit 40025 "GP Checkbook Migrator"
         GenJournalLine.Validate("Line No.", LineNum);
         GenJournalLine.Validate("Document Type", GenJournalLine."Document Type"::" ");
         GenJournalLine.Validate("Document No.", DocumentNo);
+        GenJournalLine.Validate("External Document No.", ExternalDocumentNo);
         GenJournalLine.Validate("Account Type", GenJournalLine."Account Type"::"Bank Account");
         GenJournalLine.Validate("Account No.", BankAccount);
         GenJournalLine.Validate(Description, Description);

--- a/Apps/W1/HybridGP/test/src/GPCheckBookTests.codeunit.al
+++ b/Apps/W1/HybridGP/test/src/GPCheckBookTests.codeunit.al
@@ -324,6 +324,7 @@ codeunit 139678 "GP Checkbook Tests"
         GenJournalLine: Record "Gen. Journal Line";
         HelperFunctions: Codeunit "Helper Functions";
     begin
+#pragma warning disable AA0210
         // [SCENARIO] CheckBooks are migrated from GP
         // [GIVEN] There are no records in the BankAcount table
         ClearTables();
@@ -389,7 +390,9 @@ codeunit 139678 "GP Checkbook Tests"
         BankAccountLedger.SetRange("Bank Account No.", UpperCase(MyBankStr4Txt));
         Assert.RecordCount(BankAccountLedger, 4);
 
-        BankAccountLedger.SetRange("Document No.", Format(525));
+        BankAccountLedger.SetRange("Document No.", 'XFR000000001');
+        BankAccountLedger.SetFilter(Amount, '>0');
+
         BankAccountLedger.FindFirst();
         Assert.AreEqual(100.00, BankAccountLedger.Amount, 'Transfer amount is wrong for Trx 520, MyBank4');
 
@@ -397,9 +400,11 @@ codeunit 139678 "GP Checkbook Tests"
         BankAccountLedger.SetRange("Bank Account No.", UpperCase(MyBankStr5Txt));
         Assert.RecordCount(BankAccountLedger, 7);
 
-        BankAccountLedger.SetRange("Document No.", Format(520));
+        BankAccountLedger.SetRange("Document No.", 'XFR000000001');
+        BankAccountLedger.SetFilter(Amount, '<0');
         BankAccountLedger.FindFirst();
         Assert.AreEqual(-100.00, BankAccountLedger.Amount, 'Transfer amount is wrong for Trx 520, MyBank5');
+#pragma warning restore AA0240
     end;
 
     [Test]
@@ -606,6 +611,7 @@ codeunit 139678 "GP Checkbook Tests"
         GPCheckbookTransactions.TRXAMNT := 395.59;
         GPCheckbookTransactions.CMLinkID := '1000';
         GPCheckbookTransactions.DSCRIPTN := 'APCheck1 - Vendor Check';
+        GPCheckbookTransactions.CMTrxNum := '100';
         GPCheckbookTransactions.Insert(true);
 
         GPCheckbookTransactions.Init();
@@ -616,6 +622,7 @@ codeunit 139678 "GP Checkbook Tests"
         GPCheckbookTransactions.TRXAMNT := 500.00;
         GPCheckbookTransactions.CMLinkID := '1000';
         GPCheckbookTransactions.DSCRIPTN := 'Deposit1';
+        GPCheckbookTransactions.CMTrxNum := '120';
         GPCheckbookTransactions.Insert(true);
 
         GPCheckbookTransactions.Init();
@@ -626,6 +633,7 @@ codeunit 139678 "GP Checkbook Tests"
         GPCheckbookTransactions.TRXAMNT := 250.00;
         GPCheckbookTransactions.CMLinkID := '1000';
         GPCheckbookTransactions.DSCRIPTN := 'Receipt1';
+        GPCheckbookTransactions.CMTrxNum := '125';
         GPCheckbookTransactions.Insert(true);
 
         GPCheckbookTransactions.Init();
@@ -636,6 +644,7 @@ codeunit 139678 "GP Checkbook Tests"
         GPCheckbookTransactions.TRXAMNT := 650.00;
         GPCheckbookTransactions.CMLinkID := '2000';
         GPCheckbookTransactions.DSCRIPTN := 'APCheck2 - NonVendor Check';
+        GPCheckbookTransactions.CMTrxNum := '130';
         GPCheckbookTransactions.Insert(true);
 
         GPCheckbookTransactions.Init();
@@ -646,6 +655,7 @@ codeunit 139678 "GP Checkbook Tests"
         GPCheckbookTransactions.TRXAMNT := 450.36;
         GPCheckbookTransactions.CMLinkID := '1000';
         GPCheckbookTransactions.DSCRIPTN := 'APCheck3 - Vendor Check';
+        GPCheckbookTransactions.CMTrxNum := '200';
         GPCheckbookTransactions.Insert(true);
 
         GPCheckbookTransactions.Init();
@@ -656,6 +666,7 @@ codeunit 139678 "GP Checkbook Tests"
         GPCheckbookTransactions.TRXAMNT := 450.36;
         GPCheckbookTransactions.CMLinkID := '3000';
         GPCheckbookTransactions.DSCRIPTN := 'APCheck4 - NonVendor Check';
+        GPCheckbookTransactions.CMTrxNum := '210';
         GPCheckbookTransactions.Insert(true);
 
         GPCheckbookTransactions.Init();
@@ -666,6 +677,7 @@ codeunit 139678 "GP Checkbook Tests"
         GPCheckbookTransactions.TRXAMNT := 200.00;
         GPCheckbookTransactions.CMLinkID := '1000';
         GPCheckbookTransactions.DSCRIPTN := 'APCheck5 - Vendor Check';
+        GPCheckbookTransactions.CMTrxNum := '400';
         GPCheckbookTransactions.Insert(true);
 
         GPCheckbookTransactions.Init();
@@ -676,6 +688,7 @@ codeunit 139678 "GP Checkbook Tests"
         GPCheckbookTransactions.TRXAMNT := 200.00;
         GPCheckbookTransactions.CMLinkID := '1000';
         GPCheckbookTransactions.DSCRIPTN := 'Withdrawl/Payroll Check1';
+        GPCheckbookTransactions.CMTrxNum := '410';
         GPCheckbookTransactions.Insert(true);
 
         GPCheckbookTransactions.Init();
@@ -686,6 +699,7 @@ codeunit 139678 "GP Checkbook Tests"
         GPCheckbookTransactions.TRXAMNT := 200.00;
         GPCheckbookTransactions.CMLinkID := '1000';
         GPCheckbookTransactions.DSCRIPTN := 'Receipt2';
+        GPCheckbookTransactions.CMTrxNum := '500';
         GPCheckbookTransactions.Insert(true);
 
         GPCheckbookTransactions.Init();
@@ -696,6 +710,7 @@ codeunit 139678 "GP Checkbook Tests"
         GPCheckbookTransactions.TRXAMNT := 200.00;
         GPCheckbookTransactions.CMLinkID := '1000';
         GPCheckbookTransactions.DSCRIPTN := 'IncreaseAdjustment1';
+        GPCheckbookTransactions.CMTrxNum := '505';
         GPCheckbookTransactions.Insert(true);
 
         GPCheckbookTransactions.Init();
@@ -706,6 +721,7 @@ codeunit 139678 "GP Checkbook Tests"
         GPCheckbookTransactions.TRXAMNT := 200.00;
         GPCheckbookTransactions.CMLinkID := '1000';
         GPCheckbookTransactions.DSCRIPTN := 'DecreaseAdjustment1';
+        GPCheckbookTransactions.CMTrxNum := '510';
         GPCheckbookTransactions.Insert(true);
 
         GPCheckbookTransactions.Init();


### PR DESCRIPTION
The following change enhances the GP migration to add additional detail to migrated checkbook/bank transactions.

- Document No. = CMTrxNum (currently from CMRECNUM)
- Description = paidtorcvdfrom (currently DSCRIPTN)
- External Document No. = CMLinkID (currently not set)

Source table: CM20200