### PR TITLE
Ability to run the Historical Snapshot in a Session or Background Job

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Support/WizardIntegration.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/WizardIntegration.codeunit.al
@@ -134,11 +134,6 @@ codeunit 4035 "Wizard Integration"
         exit(codeunit::"Wizard Integration");
     end;
 
-    local procedure GetDefaultGPHistoricalMigrationJobTimeoutDuration(): Integer
-    begin
-        exit(48 * 60 * 60 * 1000); // 48 hours
-    end;
-
     local procedure GetDefaultGPHistoricalMigrationJobMaxAttempts(): Integer
     begin
         exit(10);
@@ -193,7 +188,7 @@ codeunit 4035 "Wizard Integration"
                 exit;
             end;
 
-            TimeoutDuration := GetDefaultGPHistoricalMigrationJobTimeoutDuration();
+            TimeoutDuration := GPUpgradeSettings."Snapshot Timeout";
             MaxAttempts := GetDefaultGPHistoricalMigrationJobMaxAttempts();
 
             OnBeforeCreateGPHistoricalMigrationJob(IsHandled, OverrideTimeoutDuration, OverrideMaxAttempts);

--- a/Apps/W1/HybridGP/app/src/pages/GPMigrationConfiguration.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPMigrationConfiguration.Page.al
@@ -623,6 +623,9 @@ page 4050 "GP Migration Configuration"
                 Caption = 'Upgrade settings';
                 ToolTip = 'Change the settings for the GP upgrade.';
                 RunObject = page "GP Upgrade Settings";
+                Promoted = true;
+                PromotedCategory = Process;
+                PromotedOnly = true;
                 Image = Setup;
 
             }

--- a/Apps/W1/HybridGP/app/src/pages/GPUpgradeSettings.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPUpgradeSettings.Page.al
@@ -44,6 +44,23 @@ page 40043 "GP Upgrade Settings"
                     ToolTip = 'Specifies whether to log all record changes during upgrade. This method will make the data upgrade slower.';
                 }
             }
+
+            group(HistoricalSnapshot)
+            {
+                Caption = 'Historical Snapshot';
+                field(SnapshotMode; Rec."Snapshot Mode")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Snapshot Mode';
+                    ToolTip = 'Specifies whether to schedule the Historical Snapshot as a Session or Job Queue.';
+                }
+                field(SnapshotTimeout; Rec."Snapshot Timeout")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Snapshot Timeout';
+                    ToolTip = 'Specifies the timeout duration of the Historical Snapshot Session or Job.';
+                }
+            }
         }
     }
 

--- a/Apps/W1/HybridGP/app/src/pages/GPUpgradeSettings.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPUpgradeSettings.Page.al
@@ -48,6 +48,7 @@ page 40043 "GP Upgrade Settings"
             group(HistoricalSnapshot)
             {
                 Caption = 'Historical Snapshot';
+
                 field(SnapshotMode; Rec."Snapshot Mode")
                 {
                     ApplicationArea = All;
@@ -60,6 +61,23 @@ page 40043 "GP Upgrade Settings"
                     Caption = 'Snapshot Timeout';
                     ToolTip = 'Specifies the timeout duration of the Historical Snapshot Session or Job.';
                 }
+            }
+
+            label(SnapshotModesHeader)
+            {
+                ApplicationArea = All;
+                Caption = 'Historical Snapshot modes';
+                Style = Strong;
+            }
+            label(SnapshotModeBackgroundSession)
+            {
+                ApplicationArea = All;
+                Caption = 'Background session: Choose this option if you are a Delegated Admin.';
+            }
+            label(SnapshotModeJobQueue)
+            {
+                ApplicationArea = All;
+                Caption = 'Job Queue: Choose this option if the Companies have a substantial volume of historical data. Required permissions include Super user, permission to schedule a task, and have Write permission to the Job Queue table. Delegated Admins should not choose this option as they don''t meet the requirements.';
             }
         }
     }

--- a/Apps/W1/HybridGP/app/src/pages/IntelligentCloudExtension.PageExt.al
+++ b/Apps/W1/HybridGP/app/src/pages/IntelligentCloudExtension.PageExt.al
@@ -31,6 +31,11 @@ pageextension 4015 "Intelligent Cloud Extension" extends "Intelligent Cloud Mana
 
     actions
     {
+        modify(RunDataUpgrade)
+        {
+            Visible = UseTwoStepProcess;
+        }
+
         addafter(RunReplicationNow)
         {
             action(ConfigureGPMigration)
@@ -74,9 +79,6 @@ pageextension 4015 "Intelligent Cloud Extension" extends "Intelligent Cloud Mana
                         exit;
                     end;
 
-                    if not TaskScheduler.CanCreateTask() then
-                        Error(HistoricalSnapshotJobNeedPermissionsMsg);
-
                     if Confirm(ConfirmRerunQst) then begin
                         if not GPHistSourceProgress.IsEmpty() then begin
                             HistMigrationCurrentStatus.EnsureInit();
@@ -85,7 +87,6 @@ pageextension 4015 "Intelligent Cloud Extension" extends "Intelligent Cloud Mana
                         end;
 
                         WizardIntegration.ScheduleGPHistoricalSnapshotMigration();
-                        Message(SnapshotJobRunningMsg);
                     end;
                 end;
             }
@@ -98,6 +99,7 @@ pageextension 4015 "Intelligent Cloud Extension" extends "Intelligent Cloud Mana
         HybridCompany: Record "Hybrid Company";
         GPConfiguration: Record "GP Configuration";
         GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPUpgradeSettings: Record "GP Upgrade Settings";
         HybridGPWizard: Codeunit "Hybrid GP Wizard";
         UserPermissions: Codeunit "User Permissions";
     begin
@@ -108,6 +110,9 @@ pageextension 4015 "Intelligent Cloud Extension" extends "Intelligent Cloud Mana
 
         HybridCompany.SetRange(Replicate, true);
         HasCompletedSetupWizard := not HybridCompany.IsEmpty();
+
+        GPUpgradeSettings.GetonInsertGPUpgradeSettings(GPUpgradeSettings);
+        UseTwoStepProcess := not GPUpgradeSettings."One Step Upgrade";
 
         GPConfiguration.GetSingleInstance();
 
@@ -141,11 +146,10 @@ pageextension 4015 "Intelligent Cloud Extension" extends "Intelligent Cloud Mana
         IsSuper: Boolean;
         FactBoxesVisible: Boolean;
         HasCompletedSetupWizard: Boolean;
+        UseTwoStepProcess: Boolean;
         DetailSnapshotNotConfiguredMsg: Label 'GP Historical Snapshot is not configured to migrate.';
         ConfirmRerunQst: Label 'Are you sure you want to rerun the GP Historical Snapshot migration?';
         ResetPreviousRunQst: Label 'Do you want to reset your previous GP Historical Snapshot migration? Choose No if you want to continue progress from the previous attempt.';
-        SnapshotJobRunningMsg: Label 'The GP Historical Snapshot job is running.';
         HistoricalDataJobNotRanMsg: Label 'The GP Historical Snapshot job has not ran.';
-        HistoricalSnapshotJobNeedPermissionsMsg: Label 'The GP Historical Snapshot job cannot be started. Your user needs permission to create a scheduled task.';
         HistoricalDataStartJobMsg: Label 'Start GP Historical Snapshot job.';
 }

--- a/Apps/W1/HybridGP/app/src/tables/GPUpgradeSettings.Table.al
+++ b/Apps/W1/HybridGP/app/src/tables/GPUpgradeSettings.Table.al
@@ -60,6 +60,18 @@ table 40150 "GP Upgrade Settings"
             DataClassification = CustomerContent;
             Caption = 'Replication Completed';
         }
+
+        field(11; "Snapshot Mode"; Option)
+        {
+            DataClassification = CustomerContent;
+            OptionCaption = 'Background session,Job Queue';
+            OptionMembers = "Background session","Job Queue";
+        }
+        field(12; "Snapshot Timeout"; Duration)
+        {
+            DataClassification = CustomerContent;
+            Caption = 'Snapshot Timeout';
+        }
     }
     keys
     {
@@ -75,6 +87,7 @@ table 40150 "GP Upgrade Settings"
         if not GPUpgradeSettings.Get() then begin
             GPUpgradeSettings."Upgrade Duration" := HybridGPManagement.GetDefaultJobTimeout();
             GPUpgradeSettings."One Step Upgrade Delay" := GetUpgradeDelay();
+            GPUpgradeSettings."Snapshot Timeout" := GetDefaultSnapshotTimeout();
             GPUpgradeSettings.Insert();
             GPUpgradeSettings.Get();
         end;
@@ -83,6 +96,11 @@ table 40150 "GP Upgrade Settings"
     internal procedure GetUpgradeDelay(): Duration
     begin
         exit(30 * 1000); // 30 seconds
+    end;
+
+    internal procedure GetDefaultSnapshotTimeout(): Duration
+    begin
+        exit(48 * 60 * 60 * 1000); // 48 hours
     end;
 
     var


### PR DESCRIPTION
This change enhances the GP migration, giving the ability to choose to run the Historical Snapshot in a new Session or as a Background Job.