### PR TITLE
GP enhancements for Payment Terms

### DIFF
--- a/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPEdit.PermissionSet.al
@@ -118,5 +118,6 @@ permissionset 4031 "HybridGP - Edit"
                     tabledata "GP PM10200" = IMD,
                     tabledata "GP PM30300" = IMD,
                     tabledata "GP RM20201" = IMD,
-                    tabledata "GP RM30201" = IMD;
+                    tabledata "GP RM30201" = IMD,
+                    tabledata "GP Migration Log" = IMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPObjects.PermissionSet.al
@@ -153,5 +153,7 @@ permissionset 4029 "HybridGP - Objects"
                     table "GP PM10200" = X,
                     table "GP PM30300" = X,
                     table "GP RM20201" = X,
-                    table "GP RM30201" = X;
+                    table "GP RM30201" = X,
+                    table "GP Migration Log" = X,
+                    page "GP Migration Log" = X;
 }

--- a/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
+++ b/Apps/W1/HybridGP/app/Permissions/HybridGPRead.PermissionSet.al
@@ -118,5 +118,6 @@ permissionset 4032 "HybridGP - Read"
                     tabledata "GP PM10200" = R,
                     tabledata "GP PM30300" = R,
                     tabledata "GP RM20201" = R,
-                    tabledata "GP RM30201" = R;
+                    tabledata "GP RM30201" = R,
+                    tabledata "GP Migration Log" = R;
 }

--- a/Apps/W1/HybridGP/app/Permissions/INTELLIGENTCLOUDHGP.PermissionSetExt.al
+++ b/Apps/W1/HybridGP/app/Permissions/INTELLIGENTCLOUDHGP.PermissionSetExt.al
@@ -109,5 +109,6 @@ permissionsetextension 4028 "INTELLIGENT CLOUD - HGP" extends "INTELLIGENT CLOUD
                   tabledata "GP PM10200" = RIMD,
                   tabledata "GP PM30300" = RIMD,
                   tabledata "GP RM20201" = RIMD,
-                  tabledata "GP RM30201" = RIMD;
+                  tabledata "GP RM30201" = RIMD,
+                  tabledata "GP Migration Log" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicHGP.permissionsetext.al
@@ -115,5 +115,6 @@ permissionsetextension 4025 "D365 BASIC - HGP" extends "D365 BASIC"
                   tabledata "GP PM10200" = RIMD,
                   tabledata "GP PM30300" = RIMD,
                   tabledata "GP RM20201" = RIMD,
-                  tabledata "GP RM30201" = RIMD;
+                  tabledata "GP RM30201" = RIMD,
+                  tabledata "GP Migration Log" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365basicisvHGP.permissionsetext.al
@@ -115,5 +115,6 @@ permissionsetextension 4026 "D365 BASIC ISV - HGP" extends "D365 BASIC ISV"
                   tabledata "GP PM10200" = RIMD,
                   tabledata "GP PM30300" = RIMD,
                   tabledata "GP RM20201" = RIMD,
-                  tabledata "GP RM30201" = RIMD;
+                  tabledata "GP RM30201" = RIMD,
+                  tabledata "GP Migration Log" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
+++ b/Apps/W1/HybridGP/app/Permissions/d365teammemberHGP.permissionsetext.al
@@ -115,5 +115,6 @@ permissionsetextension 4027 "D365 TEAM MEMBER - HGP" extends "D365 TEAM MEMBER"
                   tabledata "GP PM10200" = RIMD,
                   tabledata "GP PM30300" = RIMD,
                   tabledata "GP RM20201" = RIMD,
-                  tabledata "GP RM30201" = RIMD;
+                  tabledata "GP RM30201" = RIMD,
+                  tabledata "GP Migration Log" = RIMD;
 }

--- a/Apps/W1/HybridGP/app/src/Migration/Accounts/GPAccountMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Accounts/GPAccountMigrator.codeunit.al
@@ -14,6 +14,7 @@ codeunit 4017 "GP Account Migrator"
         PostingGroupDescriptionTxt: Label 'Migrated from GP', Locked = true;
         DescriptionTrxTxt: Label 'Migrated transaction', Locked = true;
         BeginningBalanceTrxTxt: Label 'Beginning Balance', Locked = true;
+        MigrationLogAreaTxt: Label 'Account', Locked = true;
 
 #if not CLEAN22
 #pragma warning disable AA0207
@@ -28,6 +29,7 @@ codeunit 4017 "GP Account Migrator"
     var
         GPAccount: Record "GP Account";
         GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+        GPMigrationLog: Record "GP Migration Log";
         AccountNum: Code[20];
     begin
         if RecordIdToMigrate.TableNo() <> Database::"GP Account" then
@@ -39,8 +41,10 @@ codeunit 4017 "GP Account Migrator"
         GPAccount.Get(RecordIdToMigrate);
 
         AccountNum := CopyStr(GPAccount.AcctNum.Trim(), 1, 20);
-        if AccountNum = '' then
+        if AccountNum = '' then begin
+            GPMigrationLog.InsertLog(MigrationLogAreaTxt, 'Account Index: ' + Format(GPAccount.AcctIndex), 'Account is skipped because there is no account number.');
             exit;
+        end;
 
         MigrateAccountDetails(GPAccount, Sender);
     end;

--- a/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOMigrator.codeunit.al
@@ -21,6 +21,7 @@ codeunit 40108 "GP PO Migrator"
         GPCodeTxt: Label 'GP', Locked = true;
         ItemJournalBatchNameTxt: Label 'GPPOITEMS', Comment = 'Item journal batch name for item adjustments', Locked = true;
         SimpleInvJnlNameTxt: Label 'DEFAULT', Comment = 'The default name of the item journal', Locked = true;
+        MigrationLogAreaTxt: Label 'PO', Locked = true;
         ItemJnlBatchLineNo: Integer;
         PostPurchaseOrderNoList: List of [Text];
         InitialAutomaticCostAdjustmentType: Enum "Automatic Cost Adjustment Type";
@@ -35,6 +36,7 @@ codeunit 40108 "GP PO Migrator"
         GeneralLedgerSetup: Record "General Ledger Setup";
         Vendor: Record Vendor;
         InventorySetup: Record "Inventory Setup";
+        GPMigrationLog: Record "GP Migration Log";
         DataMigrationErrorLogging: Codeunit "Data Migration Error Logging";
         PurchaseDocumentType: Enum "Purchase Document Type";
         PurchaseDocumentStatus: Enum "Purchase Document Status";
@@ -97,7 +99,10 @@ codeunit 40108 "GP PO Migrator"
                 PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
                 if PurchaseLine.IsEmpty() then
                     PurchaseHeader.Delete();
-            end;
+            end
+            else
+                GPMigrationLog.InsertLog(MigrationLogAreaTxt, GPPOP10100.PONUMBER, 'PO was skipped because the Vendor has not been migrated.');
+
         until GPPOP10100.Next() = 0;
 
         PostReceivedPurchaseLines();

--- a/Apps/W1/HybridGP/app/src/codeunits/HybridGPWizard.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/codeunits/HybridGPWizard.codeunit.al
@@ -143,6 +143,7 @@ codeunit 4015 "Hybrid GP Wizard"
         HybridCompany: Record "Hybrid Company";
         HybridCompanyStatus: Record "Hybrid Company Status";
         HybridReplicationDetail: Record "Hybrid Replication Detail";
+        GPMigrationLog: Record "GP Migration Log";
     begin
         GPCompanyMigrationSettings.Reset();
         if GPCompanyMigrationSettings.FindSet() then
@@ -159,6 +160,9 @@ codeunit 4015 "Hybrid GP Wizard"
 
         if not HybridReplicationDetail.IsEmpty() then
             HybridReplicationDetail.DeleteAll();
+
+        if not GPMigrationLog.IsEmpty() then
+            GPMigrationLog.DeleteAll();
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Company", 'OnAfterDeleteEvent', '', false, false)]
@@ -169,6 +173,7 @@ codeunit 4015 "Hybrid GP Wizard"
         HybridCompany: Record "Hybrid Company";
         HybridCompanyStatus: Record "Hybrid Company Status";
         HybridReplicationDetail: Record "Hybrid Replication Detail";
+        GPMigrationLog: Record "GP Migration Log";
     begin
         if Rec.IsTemporary() then
             exit;
@@ -188,6 +193,10 @@ codeunit 4015 "Hybrid GP Wizard"
         HybridReplicationDetail.SetRange("Company Name", Rec.Name);
         if not HybridReplicationDetail.IsEmpty() then
             HybridReplicationDetail.DeleteAll();
+
+        GPMigrationLog.SetRange("Company Name", Rec.Name);
+        if not GPMigrationLog.IsEmpty() then
+            GPMigrationLog.DeleteAll();
     end;
 
     local procedure ProcessesAreRunning(): Boolean

--- a/Apps/W1/HybridGP/app/src/pages/GPMigrationLog.Page.al
+++ b/Apps/W1/HybridGP/app/src/pages/GPMigrationLog.Page.al
@@ -1,0 +1,35 @@
+page 40133 "GP Migration Log"
+{
+    ApplicationArea = All;
+    Caption = 'GP Migration Log';
+    PageType = List;
+    SourceTable = "GP Migration Log";
+    UsageCategory = Administration;
+    Editable = false;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(General)
+            {
+                field("Company Name"; Rec."Company Name")
+                {
+                    ToolTip = 'Specifies the value of the Company Name field.';
+                }
+                field("Migration Area"; Rec."Migration Area")
+                {
+                    ToolTip = 'Specifies the value of the Migration Area field.';
+                }
+                field(Context; Rec.Context)
+                {
+                    ToolTip = 'Specifies the value of the Context field.';
+                }
+                field("Log Text"; Rec."Log Text")
+                {
+                    ToolTip = 'Specifies the value of the Log Text field.';
+                }
+            }
+        }
+    }
+}

--- a/Apps/W1/HybridGP/app/src/pages/HybridGPErrorsOverviewFb.page.al
+++ b/Apps/W1/HybridGP/app/src/pages/HybridGPErrorsOverviewFb.page.al
@@ -6,10 +6,6 @@ page 40132 "Hybrid GP Errors Overview Fb"
 {
     Caption = 'GP Upgrade Errors';
     PageType = CardPart;
-    InsertAllowed = false;
-    DelayedInsert = false;
-    ModifyAllowed = false;
-    SourceTable = "GP Migration Error Overview";
 
     layout
     {
@@ -51,23 +47,46 @@ page 40132 "Hybrid GP Errors Overview Fb"
                     end;
                 }
             }
+            cuegroup(MigrationLog)
+            {
+                ShowCaption = false;
+
+                field("Migration Log"; MigrationLogCount)
+                {
+                    Caption = 'Migration Log';
+                    ApplicationArea = All;
+                    ToolTip = 'Indicates the number of migration log entries.';
+
+                    trigger OnDrillDown()
+                    begin
+                        Page.Run(Page::"GP Migration Log");
+                    end;
+                }
+            }
         }
     }
     trigger OnAfterGetRecord()
+    var
+        GPMigrationErrorOverview: Record "GP Migration Error Overview";
     begin
-        MigrationErrorCount := Rec.Count();
+        MigrationErrorCount := GPMigrationErrorOverview.Count();
     end;
 
     trigger OnAfterGetCurrRecord()
     var
+        GPMigrationErrorOverview: Record "GP Migration Error Overview";
         HybridCompanyUpgrade: Record "Hybrid Company Status";
+        GPMigrationLog: Record "GP Migration Log";
     begin
-        MigrationErrorCount := Rec.Count();
+        MigrationErrorCount := GPMigrationErrorOverview.Count();
         HybridCompanyUpgrade.SetRange("Upgrade Status", HybridCompanyUpgrade."Upgrade Status"::Failed);
         FailedCompanyCount := HybridCompanyUpgrade.Count();
+
+        MigrationLogCount := GPMigrationLog.Count();
     end;
 
     var
         MigrationErrorCount: Integer;
         FailedCompanyCount: Integer;
+        MigrationLogCount: Integer;
 }

--- a/Apps/W1/HybridGP/app/src/pages/IntelligentCloudExtension.PageExt.al
+++ b/Apps/W1/HybridGP/app/src/pages/IntelligentCloudExtension.PageExt.al
@@ -110,11 +110,11 @@ pageextension 4015 "Intelligent Cloud Extension" extends "Intelligent Cloud Mana
         HasCompletedSetupWizard := not HybridCompany.IsEmpty();
 
         GPConfiguration.GetSingleInstance();
-
         if GetHasCompletedMigration() then
-            if GPCompanyAdditionalSettings.GetMigrateHistory() then
-                if not GPConfiguration.HasHistoricalJobRan() then
-                    ShowGPHistoricalJobNeedsToRunNotification();
+            if HybridCompany.Get(CompanyName()) then
+                if GPCompanyAdditionalSettings.GetMigrateHistory() then
+                    if not GPConfiguration.HasHistoricalJobRan() then
+                        ShowGPHistoricalJobNeedsToRunNotification();
     end;
 
     local procedure GetHasCompletedMigration(): Boolean

--- a/Apps/W1/HybridGP/app/src/tables/GPMigrationLog.Table.al
+++ b/Apps/W1/HybridGP/app/src/tables/GPMigrationLog.Table.al
@@ -1,0 +1,49 @@
+table 41006 "GP Migration Log"
+{
+    Caption = 'GP Migration Log';
+    DataPerCompany = false;
+    DataClassification = SystemMetadata;
+
+    fields
+    {
+        field(1; Id; Integer)
+        {
+            AutoIncrement = true;
+            Caption = 'Id';
+        }
+        field(2; "Company Name"; Text[30])
+        {
+            Caption = 'Company Name';
+        }
+        field(3; "Migration Area"; Text[50])
+        {
+            Caption = 'Migration Area';
+        }
+        field(4; Context; Text[50])
+        {
+            Caption = 'Context';
+        }
+        field(5; "Log Text"; Text[500])
+        {
+            Caption = 'Log Text';
+        }
+    }
+    keys
+    {
+        key(PK; Id)
+        {
+            Clustered = true;
+        }
+    }
+
+    procedure InsertLog(MigrationArea: Text[50]; ContextValue: Text[50]; LogText: Text[500])
+    var
+        GPMigrationLog: Record "GP Migration Log";
+    begin
+        GPMigrationLog."Company Name" := CopyStr(CompanyName(), 1, 30);
+        GPMigrationLog."Migration Area" := MigrationArea;
+        GPMigrationLog.Context := ContextValue;
+        GPMigrationLog."Log Text" := LogText;
+        GPMigrationLog.Insert();
+    end;
+}

--- a/Apps/W1/HybridGP/test/src/GPDataMigrationTests.codeunit.al
+++ b/Apps/W1/HybridGP/test/src/GPDataMigrationTests.codeunit.al
@@ -1013,6 +1013,1016 @@ codeunit 139664 "GP Data Migration Tests"
         Assert.AreEqual(DueDateCalculation, PaymentTerms."Due Date Calculation", StrSubstNo('Invalid Due Date Calculation for %1', CurrentPaymentTerm));
     end;
 
+    local procedure IsDateFormulaValid(DateFormulaTxt: Text): Boolean
+    var
+        DateFormulaObj: DateFormula;
+    begin
+        exit(Evaluate(DateFormulaObj, DateFormulaTxt));
+    end;
+
+    [Test]
+    procedure TestCalculateDueDateFormulaEmptyRecord()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DateFormulaText: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] An empty record is encountered.
+        GPPaymentTerms.DUETYPE := 0;
+
+        // [THEN] The date formula string will be empty.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual('', DateFormulaText, 'The payment term date formula should be empty for an empty record.');
+
+        // Same for discount date formula
+        DateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual('', DateFormulaText, 'The payment term discount date formula should be empty for an empty record.');
+    end;
+
+    [Test]
+    procedure TestCalculateDueDateFormulaDueTypeNetDays()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DateFormulaText: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term is configured for Net Days
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Net Days";
+
+        // [WHEN] DUEDTDS < 1
+        GPPaymentTerms.DUEDTDS := 0;
+
+        // [THEN] The date formula string will be empty.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual('', DateFormulaText, 'The payment term date formula should be empty for DueType Net Days, DUEDTDS < 1.');
+
+        // [WHEN] DUEDTDS > 0
+        GPPaymentTerms.DUEDTDS := 30;
+
+        // [THEN] A valid payment term date formula will be generated.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<30D>', DateFormulaText, 'The payment term date formula is incorrect for DueType Net Days, DUEDTDS = 30.');
+    end;
+
+    [Test]
+    procedure TestCalculateDueDateFormulaDueTypeDate()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DateFormulaText: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term is configured for Date
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Date;
+
+        // [WHEN] DUEDTDS < 1
+        GPPaymentTerms.DUEDTDS := 0;
+
+        // [THEN] The date formula string will be empty.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual('', DateFormulaText, 'The payment term date formula should be empty for DueType Date, DUEDTDS < 1.');
+
+        // [WHEN] DUEDTDS > 0
+        GPPaymentTerms.DUEDTDS := 30;
+
+        // [THEN] A valid payment term date formula will be generated.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<D30>', DateFormulaText, 'The payment term date formula is incorrect for DueType Date, DUEDTDS = 30.');
+    end;
+
+    [Test]
+    procedure TestCalculateDueDateFormulaDueTypeEOM()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DateFormulaText: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term is configured for EOM
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::EOM;
+
+        // [WHEN] DUEDTDS < 1
+        GPPaymentTerms.DUEDTDS := 0;
+
+        // [THEN] The date formula string will have a correct value.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<CM>', DateFormulaText, 'The payment term date formula should be correct for DueType EOM, DUEDTDS < 1.');
+
+        // [WHEN] DUEDTDS > 0
+        GPPaymentTerms.DUEDTDS := 2;
+
+        // [THEN] A valid payment term date formula will be generated.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<CM+2D>', DateFormulaText, 'The payment term date formula is incorrect for DueType EOM, DUEDTDS = 2.');
+    end;
+
+    [Test]
+    procedure TestCalculateDueDateFormulaDueTypeNone()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DateFormulaText: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term is configured for None
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::None;
+
+        // [WHEN] CalculateDateFromDays < 1
+        GPPaymentTerms.CalculateDateFromDays := 0;
+
+        // [THEN] The date formula string will have a correct value.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<0D>', DateFormulaText, 'The payment term date formula should be correct for DueType None, CalculateDateFromDays < 1.');
+
+        // [WHEN] CalculateDateFromDays > 0
+        GPPaymentTerms.CalculateDateFromDays := 2;
+
+        // [THEN] A valid payment term date formula will be generated.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<2D>', DateFormulaText, 'The payment term date formula is incorrect for DueType None, CalculateDateFromDays = 2.');
+    end;
+
+    [Test]
+    procedure TestCalculateDueDateFormulaDueTypeNextMonth()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DateFormulaText: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term is configured for Next Month
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Next Month";
+
+        // [WHEN] DUEDTDS < 1
+        GPPaymentTerms.DUEDTDS := 0;
+
+        // [THEN] The date formula string will have a correct value.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<-CM+1M+0D>', DateFormulaText, 'The payment term date formula should be correct for DueType Next Month, DUEDTDS < 1.');
+
+        // [WHEN] DUEDTDS > 0
+        GPPaymentTerms.DUEDTDS := 16;
+
+        // [THEN] A valid payment term date formula will be generated.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<-CM+1M+15D>', DateFormulaText, 'The payment term date formula is incorrect for DueType Next Month, DUEDTDS = 16.');
+    end;
+
+    [Test]
+    procedure TestCalculateDueDateFormulaDueTypeMonths()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DateFormulaText: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term is configured for Months
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Months;
+
+        // [WHEN] DUEDTDS < 1
+        GPPaymentTerms.DUEDTDS := 0;
+
+        // [THEN] The date formula string will have a correct value.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<0M+0D>', DateFormulaText, 'The payment term date formula should be correct for DueType Months, DUEDTDS < 1.');
+
+        // [WHEN] DUEDTDS > 0
+        GPPaymentTerms.DUEDTDS := 1;
+
+        // [THEN] A valid payment term date formula will be generated.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<1M+0D>', DateFormulaText, 'The payment term date formula is incorrect for DueType Months, DUEDTDS = 1.');
+    end;
+
+    [Test]
+    procedure TestCalculateDueDateFormulaDueTypeMonthDay()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DateFormulaText: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term is configured for Month/Day
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Month/Day";
+
+        // [WHEN] DueMonth and DUEDTDS < 1
+        GPPaymentTerms.DueMonth := 0;
+        GPPaymentTerms.DUEDTDS := 0;
+
+        // [THEN] The date formula string will have a correct value.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(false, IsDateFormulaValid(DateFormulaText), 'The payment term date formula should have been invalid. ' + DateFormulaText);
+        Assert.AreEqual('<M0+D0>', DateFormulaText, 'The payment term date formula should be correct for DueType Month/Day, DUEDTDS < 1.');
+
+        // [WHEN] DueMonth and DUEDTDS > 0
+        GPPaymentTerms.DueMonth := 1;
+        GPPaymentTerms.DUEDTDS := 1;
+
+        // [THEN] A valid payment term date formula will be generated.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<M1+D1>', DateFormulaText, 'The payment term date formula is incorrect for DueType Month/Day, DueMonth = 1, DUEDTDS = 1.');
+    end;
+
+    [Test]
+    procedure TestCalculateDueDateFormulaDueTypeAnnual()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DateFormulaText: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term is configured for Annual
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Annual;
+
+        // [WHEN] CalculateDateFromDays and DUEDTDS < 1
+        GPPaymentTerms.CalculateDateFromDays := 0;
+        GPPaymentTerms.DUEDTDS := 0;
+
+        // [THEN] The date formula string will have a correct value.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<0Y+0D>', DateFormulaText, 'The payment term date formula should be correct for DueType Annual, DUEDTDS < 1.');
+
+        // [WHEN] CalculateDateFromDays and DUEDTDS > 0
+        GPPaymentTerms.CalculateDateFromDays := 15;
+        GPPaymentTerms.DUEDTDS := 1;
+
+        // [THEN] A valid payment term date formula will be generated.
+        DateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, false, '');
+        Assert.AreEqual(true, IsDateFormulaValid(DateFormulaText), 'The payment term date formula is invalid. ' + DateFormulaText);
+        Assert.AreEqual('<1Y+15D>', DateFormulaText, 'The payment term date formula is incorrect for DueType Annual, CalculateDateFromDays = 15, DUEDTDS = 1.');
+    end;
+
+    [Test]
+    procedure TestCalculateDiscountDateFormulaDueTypeDays()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DiscountDateFormulaText: Text;
+        CombinedDateFormulaText: Text;
+        ExpectedDiscountDateFormulaMinusBrackets: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term discount is configured.
+        GPPaymentTerms.DISCTYPE := GPPaymentTerms.DISCTYPE::Days;
+
+        // [WHEN] DISCDTDS < 1
+        GPPaymentTerms.DISCDTDS := 0;
+
+        // [THEN] The date formula string will be empty.
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual('', DiscountDateFormulaText, 'The payment term discount date formula should be empty.');
+
+        // [WHEN] DISCDTDS > 0
+        GPPaymentTerms.DISCDTDS := 15;
+
+        // [THEN] A valid payment term date formula will be generated.
+        ExpectedDiscountDateFormulaMinusBrackets := '15D';
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>', DiscountDateFormulaText, 'The payment term discount date formula is incorrect.');
+
+        // [WHEN] Combined with Due Date calculation, the correct combined date formula text will be correct.
+        // [THEN] A valid payment term date formula will be generated.
+
+        // Net Days
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Net Days";
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+30D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 1');
+
+        // Date
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Date;
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+D30>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 2');
+
+        // EOM
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::EOM;
+        GPPaymentTerms.DUEDTDS := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+CM+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 3');
+
+        // None
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::None;
+        GPPaymentTerms.CalculateDateFromDays := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 4');
+
+        // Next Month
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Next Month";
+        GPPaymentTerms.DUEDTDS := 16;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '-CM+1M+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 5');
+
+        // Months
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Months;
+        GPPaymentTerms.DUEDTDS := 1;
+        GPPaymentTerms.CalculateDateFromDays := 0;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+1M+0D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 6');
+
+        // Month/Day
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Month/Day";
+        GPPaymentTerms.DueMonth := 1;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+M1+D1>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 7');
+
+        // Annual
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Annual;
+        GPPaymentTerms.CalculateDateFromDays := 15;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+1Y+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 8');
+    end;
+
+    [Test]
+    procedure TestCalculateDiscountDateFormulaDueTypeDate()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DiscountDateFormulaText: Text;
+        CombinedDateFormulaText: Text;
+        ExpectedDiscountDateFormulaMinusBrackets: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term discount is configured.
+        GPPaymentTerms.DISCTYPE := GPPaymentTerms.DISCTYPE::Date;
+
+        // [WHEN] DISCDTDS < 1
+        GPPaymentTerms.DISCDTDS := 0;
+
+        // [THEN] The date formula string will be empty.
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual('', DiscountDateFormulaText, 'The payment term discount date formula should be empty.');
+
+        // [WHEN] DISCDTDS > 0
+        GPPaymentTerms.DISCDTDS := 15;
+
+        // [THEN] A valid payment term date formula will be generated.
+        ExpectedDiscountDateFormulaMinusBrackets := 'D15';
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>', DiscountDateFormulaText, 'The payment term discount date formula is incorrect.');
+
+        // [WHEN] Combined with Due Date calculation, the correct combined date formula text will be correct.
+        // [THEN] A valid payment term date formula will be generated.
+
+        // Net Days
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Net Days";
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+30D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 1');
+
+        // Date
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Date;
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+D30>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 2');
+
+        // EOM
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::EOM;
+        GPPaymentTerms.DUEDTDS := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+CM+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 3');
+
+        // None
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::None;
+        GPPaymentTerms.CalculateDateFromDays := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 4');
+
+        // Next Month
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Next Month";
+        GPPaymentTerms.DUEDTDS := 16;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '-CM+1M+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 5');
+
+        // Months
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Months;
+        GPPaymentTerms.DUEDTDS := 1;
+        GPPaymentTerms.CalculateDateFromDays := 0;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+1M+0D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 6');
+
+        // Month/Day
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Month/Day";
+        GPPaymentTerms.DueMonth := 1;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+M1+D1>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 7');
+
+        // Annual
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Annual;
+        GPPaymentTerms.CalculateDateFromDays := 15;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+1Y+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 8');
+    end;
+
+    [Test]
+    procedure TestCalculateDiscountDateFormulaDueTypeEOM()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DiscountDateFormulaText: Text;
+        CombinedDateFormulaText: Text;
+        ExpectedDiscountDateFormulaMinusBrackets: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term discount is configured.
+        GPPaymentTerms.DISCTYPE := GPPaymentTerms.DISCTYPE::EOM;
+
+        // [WHEN] DISCDTDS < 1
+        GPPaymentTerms.DISCDTDS := 0;
+
+        // [THEN] The date formula string will be correct.
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<CM>', DiscountDateFormulaText, 'The payment term discount date formula is not correct.');
+
+        // [WHEN] DISCDTDS > 0
+        GPPaymentTerms.DISCDTDS := 2;
+
+        // [THEN] A valid date formula will be generated.
+        ExpectedDiscountDateFormulaMinusBrackets := 'CM+2D';
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>', DiscountDateFormulaText, 'The payment term discount date formula is incorrect.');
+
+        // [WHEN] Combined with Due Date calculation, the correct combined date formula text will be correct.
+        // [THEN] A valid payment term date formula will be generated.
+
+        // Net Days
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Net Days";
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+30D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 1');
+
+        // Date
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Date;
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+D30>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 2');
+
+        // EOM
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::EOM;
+        GPPaymentTerms.DUEDTDS := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+CM+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 3');
+
+        // None
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::None;
+        GPPaymentTerms.CalculateDateFromDays := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 4');
+
+        // Next Month
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Next Month";
+        GPPaymentTerms.DUEDTDS := 16;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '-CM+1M+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 5');
+
+        // Months
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Months;
+        GPPaymentTerms.DUEDTDS := 1;
+        GPPaymentTerms.CalculateDateFromDays := 0;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+1M+0D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 6');
+
+        // Month/Day
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Month/Day";
+        GPPaymentTerms.DueMonth := 1;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+M1+D1>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 7');
+
+        // Annual
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Annual;
+        GPPaymentTerms.CalculateDateFromDays := 15;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+1Y+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 8');
+    end;
+
+    [Test]
+    procedure TestCalculateDiscountDateFormulaDueTypeNone()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DiscountDateFormulaText: Text;
+        CombinedDateFormulaText: Text;
+        ExpectedDiscountDateFormulaMinusBrackets: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term discount is configured.
+        GPPaymentTerms.DISCTYPE := GPPaymentTerms.DISCTYPE::None;
+
+        // [WHEN] CalculateDateFromDays < 1
+        GPPaymentTerms.CalculateDateFromDays := -1;
+
+        // [THEN] The date formula string will be empty.
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<+0D>', DiscountDateFormulaText, 'The payment term discount date formula is not correct.');
+
+        // [WHEN] CalculateDateFromDays > 0
+        GPPaymentTerms.CalculateDateFromDays := 2;
+
+        // [THEN] The date formula string will be empty.
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<+2D>', DiscountDateFormulaText, 'The payment term discount date formula is not correct.');
+
+        // [THEN] A valid date formula will be generated.
+        ExpectedDiscountDateFormulaMinusBrackets := '+2D';
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>', DiscountDateFormulaText, 'The payment term discount date formula is incorrect.');
+
+        // [WHEN] Combined with Due Date calculation, the correct combined date formula text will be correct.
+        // [THEN] A valid payment term date formula will be generated.
+
+        // Net Days
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Net Days";
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+32D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 1');
+
+        // Date
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Date;
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+D30>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 2');
+
+        // EOM
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::EOM;
+        GPPaymentTerms.DUEDTDS := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+CM+4D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 3');
+
+        // None
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::None;
+        GPPaymentTerms.CalculateDateFromDays := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 4');
+
+        // Next Month
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Next Month";
+        GPPaymentTerms.DUEDTDS := 16;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '-CM+1M+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 5');
+
+        // Months
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Months;
+        GPPaymentTerms.DUEDTDS := 1;
+        GPPaymentTerms.CalculateDateFromDays := 0;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+1M+0D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 6');
+
+        // Month/Day
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Month/Day";
+        GPPaymentTerms.DueMonth := 1;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+M1+D1>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 7');
+
+        // Annual
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Annual;
+        GPPaymentTerms.CalculateDateFromDays := 15;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+1Y+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 8');
+    end;
+
+    [Test]
+    procedure TestCalculateDiscountDateFormulaDueTypeNextMonth()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DiscountDateFormulaText: Text;
+        CombinedDateFormulaText: Text;
+        ExpectedDiscountDateFormulaMinusBrackets: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term discount is configured.
+        GPPaymentTerms.DISCTYPE := GPPaymentTerms.DISCTYPE::"Next Month";
+
+        // [WHEN] DISCDTDS < 1
+        GPPaymentTerms.DISCDTDS := 0;
+
+        // [THEN] The date formula string will be correct.
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<-CM+1M+0D>;', DiscountDateFormulaText, 'The payment term discount date formula is not correct.');
+
+        // [WHEN] DISCDTDS > 0
+        GPPaymentTerms.DISCDTDS := 3;
+
+        // [THEN] A valid date formula will be generated.
+        ExpectedDiscountDateFormulaMinusBrackets := '-CM+1M+2D';
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>;', DiscountDateFormulaText, 'The payment term discount date formula is incorrect.');
+
+        // [WHEN] Combined with Due Date calculation, the correct combined date formula text will be correct.
+        // [THEN] A valid payment term date formula will be generated.
+
+        // Net Days
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Net Days";
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+30D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 1');
+
+        // Date
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Date;
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+D30>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 2');
+
+        // EOM
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::EOM;
+        GPPaymentTerms.DUEDTDS := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+CM+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 3');
+
+        // None
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::None;
+        GPPaymentTerms.CalculateDateFromDays := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 4');
+
+        // Next Month
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Next Month";
+        GPPaymentTerms.DUEDTDS := 16;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>-CM+1M+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 5');
+
+        // Months
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Months;
+        GPPaymentTerms.DUEDTDS := 1;
+        GPPaymentTerms.CalculateDateFromDays := 0;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+1M+0D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 6');
+
+        // Month/Day
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Month/Day";
+        GPPaymentTerms.DueMonth := 1;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+M1+D1>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 7');
+
+        // Annual
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Annual;
+        GPPaymentTerms.CalculateDateFromDays := 15;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+1Y+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 8');
+    end;
+
+    [Test]
+    procedure TestCalculateDiscountDateFormulaDueTypeMonths()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DiscountDateFormulaText: Text;
+        CombinedDateFormulaText: Text;
+        ExpectedDiscountDateFormulaMinusBrackets: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term discount is configured.
+        GPPaymentTerms.DISCTYPE := GPPaymentTerms.DISCTYPE::Months;
+
+        // [WHEN] CalculateDateFromDays and DISCDTDS < 1
+        GPPaymentTerms.CalculateDateFromDays := 0;
+        GPPaymentTerms.DISCDTDS := 0;
+
+        // [THEN] The date formula string will be correct.
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<0M+0D>;', DiscountDateFormulaText, 'The payment term discount date formula is not correct.');
+
+        // [WHEN] DISCDTDS > 0
+        GPPaymentTerms.DISCDTDS := 1;
+
+        // [THEN] A valid date formula will be generated.
+        ExpectedDiscountDateFormulaMinusBrackets := '1M+0D';
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>;', DiscountDateFormulaText, 'The payment term discount date formula is incorrect.');
+
+        // [WHEN] Combined with Due Date calculation, the correct combined date formula text will be correct.
+        // [THEN] A valid payment term date formula will be generated.
+
+        // Net Days
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Net Days";
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+30D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 1');
+
+        // Date
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Date;
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+D30>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 2');
+
+        // EOM
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::EOM;
+        GPPaymentTerms.DUEDTDS := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+CM+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 3');
+
+        // None
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::None;
+        GPPaymentTerms.CalculateDateFromDays := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 4');
+
+        // Next Month
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Next Month";
+        GPPaymentTerms.DUEDTDS := 16;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>-CM+1M+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 5');
+
+        // Months
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Months;
+        GPPaymentTerms.DUEDTDS := 1;
+        GPPaymentTerms.CalculateDateFromDays := 0;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+1M+0D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 6');
+
+        // Month/Day
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Month/Day";
+        GPPaymentTerms.DueMonth := 1;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+M1+D1>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 7');
+
+        // Annual
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Annual;
+        GPPaymentTerms.CalculateDateFromDays := 15;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+1Y+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 8');
+    end;
+
+    [Test]
+    procedure TestCalculateDiscountDateFormulaDueTypeMonthDay()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DiscountDateFormulaText: Text;
+        CombinedDateFormulaText: Text;
+        ExpectedDiscountDateFormulaMinusBrackets: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term discount is configured.
+        GPPaymentTerms.DISCTYPE := GPPaymentTerms.DISCTYPE::"Month/Day";
+
+        // [WHEN] DiscountMonth and DISCDTDS > 1
+        GPPaymentTerms.DiscountMonth := 2;
+        GPPaymentTerms.DISCDTDS := 1;
+
+        // [THEN] A valid date formula will be generated.
+        ExpectedDiscountDateFormulaMinusBrackets := 'M2+D1';
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>', DiscountDateFormulaText, 'The payment term discount date formula is incorrect.');
+
+        // [WHEN] Combined with Due Date calculation, the correct combined date formula text will be correct.
+        // [THEN] A valid payment term date formula will be generated.
+
+        // Net Days
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Net Days";
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+30D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 1');
+
+        // Date
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Date;
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+D30>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 2');
+
+        // EOM
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::EOM;
+        GPPaymentTerms.DUEDTDS := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+CM+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 3');
+
+        // None
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::None;
+        GPPaymentTerms.CalculateDateFromDays := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 4');
+
+        // Next Month
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Next Month";
+        GPPaymentTerms.DUEDTDS := 16;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '-CM+1M+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 5');
+
+        // Months
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Months;
+        GPPaymentTerms.DUEDTDS := 1;
+        GPPaymentTerms.CalculateDateFromDays := 0;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+1M+0D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 6');
+
+        // Month/Day
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Month/Day";
+        GPPaymentTerms.DueMonth := 1;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+M1+D1>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 7');
+
+        // Annual
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Annual;
+        GPPaymentTerms.CalculateDateFromDays := 15;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '+1Y+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 8');
+    end;
+
+    [Test]
+    procedure TestCalculateDiscountDateFormulaDueTypeAnnual()
+    var
+        GPPaymentTerms: Record "GP Payment Terms";
+        DiscountDateFormulaText: Text;
+        CombinedDateFormulaText: Text;
+        ExpectedDiscountDateFormulaMinusBrackets: Text;
+    begin
+        // [SCENARIO] GP Payment Terms staging table is populated.
+        // [GIVEN] Payment term date formula calculations are to be performed.
+
+        // [WHEN] The payment term discount is configured.
+        GPPaymentTerms.DISCTYPE := GPPaymentTerms.DISCTYPE::Annual;
+
+        // [WHEN] DISCDTDS < 1
+        GPPaymentTerms.DISCDTDS := -1;
+
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<0Y+0D>;', DiscountDateFormulaText, 'The payment term discount date formula is incorrect.');
+
+        // [WHEN] DISCDTDS > 0
+        GPPaymentTerms.DISCDTDS := 1;
+
+        // [THEN] A valid date formula will be generated.
+        ExpectedDiscountDateFormulaMinusBrackets := '1Y+0D';
+        DiscountDateFormulaText := HelperFunctions.CalculateDiscountDateFormula(GPPaymentTerms);
+        Assert.AreEqual(true, IsDateFormulaValid(DiscountDateFormulaText), 'The payment term discount date formula is invalid. ' + DiscountDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>;', DiscountDateFormulaText, 'The payment term discount date formula is incorrect.');
+
+        // [WHEN] Combined with Due Date calculation, the correct combined date formula text will be correct.
+        // [THEN] A valid payment term date formula will be generated.
+
+        // Net Days
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Net Days";
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+30D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 1');
+
+        // Date
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Date;
+        GPPaymentTerms.DUEDTDS := 30;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+D30>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 2');
+
+        // EOM
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::EOM;
+        GPPaymentTerms.DUEDTDS := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+CM+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 3');
+
+        // None
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::None;
+        GPPaymentTerms.CalculateDateFromDays := 2;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+2D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 4');
+
+        // Next Month
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Next Month";
+        GPPaymentTerms.DUEDTDS := 16;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>-CM+1M+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 5');
+
+        // Months
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Months;
+        GPPaymentTerms.DUEDTDS := 1;
+        GPPaymentTerms.CalculateDateFromDays := 0;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+1M+0D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 6');
+
+        // Month/Day
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::"Month/Day";
+        GPPaymentTerms.DueMonth := 1;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+M1+D1>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 7');
+
+        // Annual
+        GPPaymentTerms.DUETYPE := GPPaymentTerms.DUETYPE::Annual;
+        GPPaymentTerms.CalculateDateFromDays := 15;
+        GPPaymentTerms.DUEDTDS := 1;
+        CombinedDateFormulaText := HelperFunctions.CalculateDueDateFormula(GPPaymentTerms, true, CopyStr(DiscountDateFormulaText, 1, 32));
+        Assert.AreEqual(true, IsDateFormulaValid(CombinedDateFormulaText), 'The combined payment term date formula is invalid. ' + CombinedDateFormulaText);
+        Assert.AreEqual('<' + ExpectedDiscountDateFormulaMinusBrackets + '>+1Y+15D>', CombinedDateFormulaText, 'The combined payment term date formula is incorrect. 8');
+    end;
+
     local procedure CreateGPPaymentTermsRecords()
     var
         GPPaymentTerms: Record "GP Payment Terms";


### PR DESCRIPTION
This PR contains changes to the GP migration to harden the code around Payment Terms creation.
This change also includes a migration log. Currently, these are the scenarios that will be logged:

- The Payment Term "Discount Date Calculation" could not be set because it is considered invalid.
- The Payment Term "Due Date Calculation" could not be set because it is considered invalid.
- Skipped creating an Account because there isn't an account number.
- Skipped creating a PO because the Vendor has not been migrated.