### PR TITLE
PO migration should filter out inactive items if the user is not migrating inactive or discontinued items

### DIFF
--- a/Apps/W1/HybridGP/app/src/Migration/Items/GPIV00101.Table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Items/GPIV00101.Table.al
@@ -91,6 +91,11 @@ table 40116 "GP IV00101"
         exit(Rec.ITEMTYPE = DiscontinuedItemTypeId());
     end;
 
+    procedure IsInventoryItem(): Boolean
+    begin
+        exit((Rec.ITEMTYPE = 1) or (Rec.ITEMTYPE = 2));
+    end;
+
     procedure GetRoundingPrecision(GPDecimalPlaceId: Integer): Decimal
     begin
         case GPDecimalPlaceId of

--- a/Apps/W1/HybridGP/app/src/Migration/Items/GPItemMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Items/GPItemMigrator.codeunit.al
@@ -41,6 +41,7 @@ codeunit 4019 "GP Item Migrator"
     var
         GPItem: Record "GP Item";
         DataMigrationErrorLogging: Codeunit "Data Migration Error Logging";
+        HelperFunctions: Codeunit "Helper Functions";
     begin
         if RecordIdToMigrate.TableNo() <> Database::"GP Item" then
             exit;
@@ -49,29 +50,12 @@ codeunit 4019 "GP Item Migrator"
         if not GPItem.Get(RecordIdToMigrate) then
             exit;
 
-        if not ShouldMigrateItem(GPItem) then begin
+        if not HelperFunctions.ShouldMigrateItem(GPItem.No) then begin
             DecrementMigratedCount();
             exit;
         end;
 
         MigrateItemDetails(GPItem, Sender);
-    end;
-
-    local procedure ShouldMigrateItem(var GPItem: Record "GP Item"): Boolean
-    var
-        GPIV00101: Record "GP IV00101";
-    begin
-        if GPIV00101.Get(GPItem.No) then begin
-            if GPIV00101.INACTIVE then
-                if not GPCompanyAdditionalSettings.GetMigrateInactiveItems() then
-                    exit(false);
-
-            if GPIV00101.IsDiscontinued() then
-                if not GPCompanyAdditionalSettings.GetMigrateDiscontinuedItems() then
-                    exit(false);
-        end;
-
-        exit(true);
     end;
 
     local procedure DecrementMigratedCount()

--- a/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/HelperFunctions.codeunit.al
@@ -1967,6 +1967,23 @@ codeunit 4037 "Helper Functions"
         DataMigrationErrorLogging.ClearLastRecordUnderProcessing();
     end;
 
+    internal procedure ShouldMigrateItem(ItemNo: Text): Boolean
+    var
+        GPIV00101: Record "GP IV00101";
+        GPCompanyAdditionalSettings: Record "GP Company Additional Settings";
+    begin
+        if GPIV00101.Get(ItemNo) then begin
+            if GPIV00101.INACTIVE then
+                if not GPCompanyAdditionalSettings.GetMigrateInactiveItems() then
+                    exit(false);
+
+            if GPIV00101.IsDiscontinued() then
+                if not GPCompanyAdditionalSettings.GetMigrateDiscontinuedItems() then
+                    exit(false);
+        end;
+
+        exit(true);
+    end;
     [IntegrationEvent(false, false)]
     local procedure OnSkipPostingGLAccounts(var SkipPosting: Boolean)
     begin

--- a/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOMigrator.codeunit.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOMigrator.codeunit.al
@@ -21,6 +21,9 @@ codeunit 40108 "GP PO Migrator"
         GPCodeTxt: Label 'GP', Locked = true;
         ItemJournalBatchNameTxt: Label 'GPPOITEMS', Comment = 'Item journal batch name for item adjustments', Locked = true;
         SimpleInvJnlNameTxt: Label 'DEFAULT', Comment = 'The default name of the item journal', Locked = true;
+        MigrationLogAreaTxt: Label 'PO', Locked = true;
+        POLineSkippedWarningTxt: Label 'PO line skipped because the item was not migrated. %1', Comment = '%1 = Reason';
+        POLineCouldNotBeCreatedErr: Label 'PO line could not be created because the item was expected to exist but does not. Reason unknown. %1', Comment = '%1 Identifier';
         ItemJnlBatchLineNo: Integer;
         PostPurchaseOrderNoList: List of [Text];
         InitialAutomaticCostAdjustmentType: Enum "Automatic Cost Adjustment Type";
@@ -35,6 +38,7 @@ codeunit 40108 "GP PO Migrator"
         GeneralLedgerSetup: Record "General Ledger Setup";
         Vendor: Record Vendor;
         InventorySetup: Record "Inventory Setup";
+        //GPMigrationWarnings: Record "GP Migration Warnings";
         DataMigrationErrorLogging: Codeunit "Data Migration Error Logging";
         PurchaseDocumentType: Enum "Purchase Document Type";
         PurchaseDocumentStatus: Enum "Purchase Document Status";
@@ -96,8 +100,9 @@ codeunit 40108 "GP PO Migrator"
                 PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
                 PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
                 if PurchaseLine.IsEmpty() then
-                    PurchaseHeader.Delete();
-            end;
+                    PurchaseHeader.Delete()
+            end;// else
+                //GPMigrationWarnings.InsertWarning(MigrationLogAreaTxt, GPPOP10100.PONUMBER, 'PO was skipped because the Vendor has not been migrated.');
         until GPPOP10100.Next() = 0;
 
         PostReceivedPurchaseLines();
@@ -138,7 +143,10 @@ codeunit 40108 "GP PO Migrator"
         GPPOP10110: Record "GP POP10110";
         GPPOPReceiptApply: Record GPPOPReceiptApply;
         GPPOPReceiptApplyLineUnitCost: Record GPPOPReceiptApply;
+        Item: Record Item;
+        //GPMigrationWarnings: Record "GP Migration Warnings";
         DataMigrationErrorLogging: Codeunit "Data Migration Error Logging";
+        HelperFunctions: Codeunit "Helper Functions";
         LineQuantityRemaining: Decimal;
         LineNo: Integer;
         LocationCode: Code[10];
@@ -147,6 +155,9 @@ codeunit 40108 "GP PO Migrator"
         LastLineUnitCost: Decimal;
         LineQtyReceivedByUnitCost: Decimal;
         LineQtyInvoicedByUnitCost: Decimal;
+        ItemNo: Text;
+        ShouldCreateLine: Boolean;
+        NotMigratedWarningTxt: Text[500];
     begin
         GPPOP10110.SetRange(PONUMBER, PONumber);
         if not GPPOP10110.FindSet() then
@@ -156,41 +167,58 @@ codeunit 40108 "GP PO Migrator"
         repeat
             LastLocation := '';
             LastLineUnitCost := 0;
+            ShouldCreateLine := true;
 
-            LineQuantityRemaining := GPPOP10110.QTYORDER - GPPOP10110.QTYCANCE;
-            if LineQuantityRemaining > 0 then begin
-                DataMigrationErrorLogging.SetLastRecordUnderProcessing(Format(GPPOP10110.RecordId));
-                GPPOPReceiptApplyLineUnitCost.SetLoadFields(TRXLOCTN, PCHRPTCT, UOFM);
-                GPPOPReceiptApplyLineUnitCost.SetCurrentKey(TRXLOCTN, PCHRPTCT);
-                GPPOPReceiptApplyLineUnitCost.SetRange(PONUMBER, GPPOP10110.PONUMBER);
-                GPPOPReceiptApplyLineUnitCost.SetRange(POLNENUM, GPPOP10110.ORD);
-                GPPOPReceiptApplyLineUnitCost.SetRange(Status, GPPOPReceiptApplyLineUnitCost.Status::Posted);
-                GPPOPReceiptApplyLineUnitCost.SetFilter(POPTYPE, '1|3');
-                GPPOPReceiptApplyLineUnitCost.SetFilter(QTYSHPPD, '>%1', 0);
-                GPPOPReceiptApplyLineUnitCost.SetFilter(PCHRPTCT, '>%1', 0);
+            ItemNo := CopyStr(GPPOP10110.ITEMNMBR.Trim(), 1, MaxStrLen(Item."No."));
+            Item.SetRange("No.", ItemNo);
+            if Item.IsEmpty() then
+                if GPPOP10110.NONINVEN = 0 then
+                    ShouldCreateLine := false;
 
-                if GPPOPReceiptApplyLineUnitCost.FindSet() then
-                    repeat
-                        if ((LastLocation <> GPPOPReceiptApplyLineUnitCost.TRXLOCTN) or (LastLineUnitCost <> GPPOPReceiptApplyLineUnitCost.PCHRPTCT)) then begin
-                            LocationCode := CopyStr(GPPOPReceiptApplyLineUnitCost.TRXLOCTN, 1, MaxStrLen(LocationCode));
-                            UnitOfMeasure := CopyStr(GPPOPReceiptApplyLineUnitCost.UOFM.Trim(), 1, MaxStrLen(UnitOfMeasure));
-                            LineQtyReceivedByUnitCost := GPPOPReceiptApply.GetSumQtyShippedByUnitCost(GPPOP10110.PONUMBER, GPPOP10110.ORD, LocationCode, GPPOPReceiptApplyLineUnitCost.PCHRPTCT);
-                            LineQtyInvoicedByUnitCost := GPPOPReceiptApply.GetSumQtyInvoicedByUnitCost(GPPOP10110.PONUMBER, GPPOP10110.ORD, LocationCode, GPPOPReceiptApplyLineUnitCost.PCHRPTCT);
+            if ShouldCreateLine then begin
+                LineQuantityRemaining := GPPOP10110.QTYORDER - GPPOP10110.QTYCANCE;
+                if LineQuantityRemaining > 0 then begin
+                    DataMigrationErrorLogging.SetLastRecordUnderProcessing(Format(GPPOP10110.RecordId));
+                    GPPOPReceiptApplyLineUnitCost.SetLoadFields(TRXLOCTN, PCHRPTCT, UOFM);
+                    GPPOPReceiptApplyLineUnitCost.SetCurrentKey(TRXLOCTN, PCHRPTCT);
+                    GPPOPReceiptApplyLineUnitCost.SetRange(PONUMBER, GPPOP10110.PONUMBER);
+                    GPPOPReceiptApplyLineUnitCost.SetRange(POLNENUM, GPPOP10110.ORD);
+                    GPPOPReceiptApplyLineUnitCost.SetRange(Status, GPPOPReceiptApplyLineUnitCost.Status::Posted);
+                    GPPOPReceiptApplyLineUnitCost.SetFilter(POPTYPE, '1|3');
+                    GPPOPReceiptApplyLineUnitCost.SetFilter(QTYSHPPD, '>%1', 0);
+                    GPPOPReceiptApplyLineUnitCost.SetFilter(PCHRPTCT, '>%1', 0);
 
-                            if (LineQtyReceivedByUnitCost > LineQtyInvoicedByUnitCost) then
-                                CreateLine(PONumber, GPPOP10110, LineQuantityRemaining, LineNo, LineQtyReceivedByUnitCost, LineQtyInvoicedByUnitCost, GPPOPReceiptApplyLineUnitCost.PCHRPTCT, LocationCode, UnitOfMeasure)
-                            else
-                                LineQuantityRemaining := LineQuantityRemaining - LineQtyReceivedByUnitCost;
+                    if GPPOPReceiptApplyLineUnitCost.FindSet() then
+                        repeat
+                            if ((LastLocation <> GPPOPReceiptApplyLineUnitCost.TRXLOCTN) or (LastLineUnitCost <> GPPOPReceiptApplyLineUnitCost.PCHRPTCT)) then begin
+                                LocationCode := CopyStr(GPPOPReceiptApplyLineUnitCost.TRXLOCTN, 1, MaxStrLen(LocationCode));
+                                UnitOfMeasure := CopyStr(GPPOPReceiptApplyLineUnitCost.UOFM.Trim(), 1, MaxStrLen(UnitOfMeasure));
+                                LineQtyReceivedByUnitCost := GPPOPReceiptApply.GetSumQtyShippedByUnitCost(GPPOP10110.PONUMBER, GPPOP10110.ORD, LocationCode, GPPOPReceiptApplyLineUnitCost.PCHRPTCT);
+                                LineQtyInvoicedByUnitCost := GPPOPReceiptApply.GetSumQtyInvoicedByUnitCost(GPPOP10110.PONUMBER, GPPOP10110.ORD, LocationCode, GPPOPReceiptApplyLineUnitCost.PCHRPTCT);
 
-                            LastLocation := GPPOPReceiptApplyLineUnitCost.TRXLOCTN;
-                            LastLineUnitCost := GPPOPReceiptApplyLineUnitCost.PCHRPTCT;
-                        end;
-                    until GPPOPReceiptApplyLineUnitCost.Next() = 0;
+                                if (LineQtyReceivedByUnitCost > LineQtyInvoicedByUnitCost) then
+                                    CreateLine(PONumber, GPPOP10110, LineQuantityRemaining, LineNo, LineQtyReceivedByUnitCost, LineQtyInvoicedByUnitCost, GPPOPReceiptApplyLineUnitCost.PCHRPTCT, LocationCode, UnitOfMeasure)
+                                else
+                                    LineQuantityRemaining := LineQuantityRemaining - LineQtyReceivedByUnitCost;
 
-                LocationCode := CopyStr(GPPOP10110.LOCNCODE.Trim(), 1, MaxStrLen(LocationCode));
-                UnitOfMeasure := CopyStr(GPPOP10110.UOFM.Trim(), 1, MaxStrLen(UnitOfMeasure));
-                if LineQuantityRemaining > 0 then
-                    CreateLine(PONumber, GPPOP10110, LineQuantityRemaining, LineNo, 0, 0, GPPOP10110.UNITCOST, LocationCode, UnitOfMeasure);
+                                LastLocation := GPPOPReceiptApplyLineUnitCost.TRXLOCTN;
+                                LastLineUnitCost := GPPOPReceiptApplyLineUnitCost.PCHRPTCT;
+                            end;
+                        until GPPOPReceiptApplyLineUnitCost.Next() = 0;
+
+                    LocationCode := CopyStr(GPPOP10110.LOCNCODE.Trim(), 1, MaxStrLen(LocationCode));
+                    UnitOfMeasure := CopyStr(GPPOP10110.UOFM.Trim(), 1, MaxStrLen(UnitOfMeasure));
+                    if LineQuantityRemaining > 0 then
+                        CreateLine(PONumber, GPPOP10110, LineQuantityRemaining, LineNo, 0, 0, GPPOP10110.UNITCOST, LocationCode, UnitOfMeasure);
+                end;
+            end
+            else begin
+                if not HelperFunctions.ShouldMigrateItem(ItemNo) then
+                    NotMigratedWarningTxt := StrSubstNo(POLineSkippedWarningTxt, 'The item is either inactive or discontinued.')
+                else
+                    NotMigratedWarningTxt := StrSubstNo(POLineSkippedWarningTxt, 'Reason unknown and should be investigated.');
+
+                //GPMigrationWarnings.InsertWarning(MigrationLogAreaTxt, PONumber + ' - ' + ItemNo, NotMigratedWarningTxt);
             end;
         until GPPOP10110.Next() = 0;
     end;
@@ -199,6 +227,7 @@ codeunit 40108 "GP PO Migrator"
     var
         PurchaseLine: Record "Purchase Line";
         Item: Record Item;
+        FoundItem: Boolean;
         PurchaseDocumentType: Enum "Purchase Document Type";
         PurchaseLineType: Enum "Purchase Line Type";
         ItemNo: Code[20];
@@ -228,8 +257,17 @@ codeunit 40108 "GP PO Migrator"
         ItemNo := CopyStr(GPPOP10110.ITEMNMBR.Trim(), 1, MaxStrLen(ItemNo));
         IsInventoryItem := false;
 
-        if Item.Get(ItemNo) then
+        Item.SetLoadFields(Type, "Over-Receipt Code");
+        if Item.Get(ItemNo) then begin
+            FoundItem := true;
             IsInventoryItem := Item.Type = Item.Type::Inventory;
+        end;
+
+        if not FoundItem then
+            if not GPPOP10110.IsInventoryItem() then
+                CreateNonInventoryItem(GPPOP10110)
+            else
+                Error(POLineCouldNotBeCreatedErr, PONumber + ' - ' + ItemNo);
 
         PurchaseLine.Init();
         PurchaseLine."Document No." := PONumber;
@@ -237,10 +275,6 @@ codeunit 40108 "GP PO Migrator"
         PurchaseLine."Line No." := LineNo;
         PurchaseLine."Buy-from Vendor No." := GPPOP10110.VENDORID;
         PurchaseLine.Type := PurchaseLineType::Item;
-
-        if GPPOP10110.NONINVEN = 1 then
-            CreateNonInventoryItem(GPPOP10110);
-
         PurchaseLine.Validate("Gen. Bus. Posting Group", GPCodeTxt);
         PurchaseLine.Validate("Gen. Prod. Posting Group", GPCodeTxt);
         PurchaseLine."Unit of Measure" := UnitOfMeasure;

--- a/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOP10110.table.al
+++ b/Apps/W1/HybridGP/app/src/Migration/Support/PurchaseOrders/GPPOP10110.table.al
@@ -128,4 +128,14 @@ table 40138 "GP POP10110"
             Clustered = true;
         }
     }
+
+    procedure IsInventoryItem(): Boolean
+    var
+        GPIV00101: Record "GP IV00101";
+    begin
+        if GPIV00101.Get(Rec.ITEMNMBR) then
+            exit(GPIV00101.IsInventoryItem() or (Rec.NONINVEN = 0));
+
+        exit(false);
+    end;
 }


### PR DESCRIPTION
If an item wasn't migrated (inactive, discontinued) and is on a PO line, the PO line will be skipped and logged as a migration warning.